### PR TITLE
Fix returning int when tuple expected in calc_alpha_at_nu

### DIFF
--- a/stardis/opacities/base.py
+++ b/stardis/opacities/base.py
@@ -366,7 +366,7 @@ def calc_alpha_line_at_nu(
     """
 
     if line_opacity_config.disable:
-        return 0
+        return 0, 0, 0
 
     broadening_methods = line_opacity_config.broadening
     _nu_min = line_opacity_config.min.to(u.Hz, u.spectral())


### PR DESCRIPTION
### :pencil: Fix returning int when tuple expected in calc_alpha_at_nu

**Type:** :beetle: `bugfix` 
Calc_alpha_at_nu is expected to return a tuple but returned an int

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
