### PR TITLE
Add TARDIS Bot comments from TARDIS Repo

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Deploy ${{ env.DEST_DIR }}
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_TOKEN }}
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: ./docs/_build/html
           destination_dir: ${{ env.DEST_DIR }}
@@ -103,7 +103,7 @@ jobs:
       - name: Post comment (success)
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token:  ${{ secrets.GITHUB_TOKEN }}
+          token:  ${{ secrets.BOT_TOKEN }}
           issue-number: ${{ github.event.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
@@ -122,7 +122,7 @@ jobs:
       - name: Post comment (failure)
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token:  ${{ secrets.GITHUB_TOKEN }}
+          token:  ${{ secrets.BOT_TOKEN }}
           issue-number: ${{ github.event.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -91,3 +91,49 @@ jobs:
           force_orphan: ${{ env.CLEAN_BRANCH }}
           user_name: 'TARDIS Bot'
           user_email: 'tardis.sn.bot@gmail.com'
+
+      - name: Find comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Hi, human.
+        if: always() && github.event_name == 'pull_request_target'
+
+      - name: Post comment (success)
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            *\*beep\* \*bop\**
+
+            Hi, human.
+
+            The **`${{ github.workflow }}`** workflow has **succeeded** :heavy_check_mark:
+            
+            [**Click here**](${{ env.URL }}) to see your results.
+        env:
+          URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ github.event.number }}/index.html
+        if: success() && github.event_name == 'pull_request_target'
+
+      - name: Post comment (failure)
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            *\*beep\* \*bop\**
+
+            Hi, human.
+
+            The **`${{ github.workflow }}`** workflow has **failed** :x:
+            
+            [**Click here**](${{ env.URL }}) to see the build log.
+        env:
+          URL: https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}?check_suite_focus=true
+        if: failure() && github.event_name == 'pull_request_target'


### PR DESCRIPTION
### :pencil: Description

**Type:** | :roller_coaster: `infrastructure`

This includes TARDIS bot actions to leave comments for success or failure of the build-docs workflow.

### :pushpin: Resources

[Original code](https://github.com/tardis-sn/tardis/blob/334c6fe7324b78599f74f1e266be0de0e3abbf79/.github/workflows/build-docs.yml#L134-L178)


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Not sure how to test this on my own branch


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
