### PR TITLE
Run build-docs.yml Only on Main Branch of tardis-sn/stardis

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,6 +11,7 @@ defaults:
     shell: bash -le {0}
 jobs:
   build-sphinx-html:
+    if: ((github.repository == 'tardis-sn/stardis') && (${{ github.head_ref || github.ref_name}} == 'main')) || (github.repository_owner != 'tardis-sn')
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,6 +12,9 @@ defaults:
 jobs:
   build-sphinx-html:
     if: ((github.repository == 'tardis-sn/stardis') && (${{ github.head_ref || github.ref_name}} == 'main')) || (github.repository_owner != 'tardis-sn')
+    # The above line makes this action run if it is either not on the upstream/main or the main branch of upstream/main.
+    # If there is a better way to implement this, I'd like someone to please share.
+    # The context to get the branch name is from https://stackoverflow.com/a/71158878
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` | :roller_coaster: `infrastructure`

This commit causes the Sphinx docs workflow to be triggered only on the main branch of tardis-sn/stardis or if it is not on a repo owned by tardis-sn. This is so that other branches do not trigger the docs to be run

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] Runs on my fork
- [X] Manual testing and debugging


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
@sonachitchyan @jvshields @jaladh-singhal @smithis7 