### PR TITLE
Trigger build docs only on upstream/main with build-docs label

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,6 +1,7 @@
 name: build-docs
 on:
   push:
+  pull_request_target:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle:  :memo: `documentation` | :roller_coaster: `infrastructure`

This commit implements the functionality that the docs will only be built on upstream in the main branch and when the build-docs label is applied. Outside of the upstream repo, building is unrestricted.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] Triggers on my fork



### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
