### PR TITLE
Change Sphinx docs theme from Alabaster to RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ intersphinx_mapping = {"https://docs.python.org/": None}
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

This pull request changes the Sphinx documentation theme from Alabaster to RTD to match the [TARDIS docs](https://tardis-sn.github.io/tardis/).

### :pushpin: Resources

[Github page for the RTD theme](https://github.com/readthedocs/sphinx_rtd_theme)

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] [Builds on my fork](https://smokestacklightnin.github.io/stardis/branch/docs/change-to-rtd-theme/)

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
