### PR TITLE
Add some basic tests for the Voigt module

### DIFF
--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -21,8 +21,27 @@ def test_faddeeva_sample_values(
     )
 
 
-@pytest.mark.parametrize("voigt_profile_division_by_zero_input_delta_nu", range(11))
-@pytest.mark.parametrize("voigt_profile_division_by_zero_input_gamma", range(11))
+test_voigt_profile_division_by_zero_test_values = [
+    -100,
+    -5,
+    -1,
+    0,
+    0.0,
+    1j,
+    1.2,
+    3,
+    100,
+]
+
+
+@pytest.mark.parametrize(
+    "voigt_profile_division_by_zero_input_delta_nu",
+    test_voigt_profile_division_by_zero_test_values,
+)
+@pytest.mark.parametrize(
+    "voigt_profile_division_by_zero_input_gamma",
+    test_voigt_profile_division_by_zero_test_values,
+)
 def test_voigt_profile_division_by_zero(
     voigt_profile_division_by_zero_input_delta_nu,
     voigt_profile_division_by_zero_input_gamma,

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -38,25 +38,25 @@ def test_voigt_profile_division_by_zero(
 
 
 @pytest.mark.parametrize(
-    "voigt_profile_input_delta_nu, voigt_profile_input_doppler_width, voigt_profile_input_gamma, voigt_profile_expected_result",
+    "voigt_profile_sample_values_input_delta_nu, voigt_profile_sample_values_input_doppler_width, voigt_profile_sample_values_input_gamma, voigt_profile_sample_values_expected_result",
     [
         (0, 1, 0, 1 / sqrt(PI)),
         (0, 2, 0, 1 / (sqrt(PI) * 2)),
     ],
 )
-def test_voigt_profile_sample_values(
-    voigt_profile_input_delta_nu,
-    voigt_profile_input_doppler_width,
-    voigt_profile_input_gamma,
-    voigt_profile_expected_result,
+def test_voigt_profile_sample_values_sample_values(
+    voigt_profile_sample_values_input_delta_nu,
+    voigt_profile_sample_values_input_doppler_width,
+    voigt_profile_sample_values_input_gamma,
+    voigt_profile_sample_values_expected_result,
 ):
     from stardis.opacities.voigt import voigt_profile
 
     assert allclose(
         voigt_profile(
-            voigt_profile_input_delta_nu,
-            voigt_profile_input_doppler_width,
-            voigt_profile_input_gamma,
+            voigt_profile_sample_values_input_delta_nu,
+            voigt_profile_sample_values_input_doppler_width,
+            voigt_profile_sample_values_input_gamma,
         ),
-        voigt_profile_expected_result,
+        voigt_profile_sample_values_expected_result,
     )

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -5,32 +5,61 @@ from stardis.opacities import voigt
 
 
 @pytest.mark.parametrize(
-    "faddeeva_input, faddeeva_expected_result",
+    "faddeeva_sample_values_input, faddeeva_sample_values_expected_result",
     [
         (0, 1 + 0j),
         (0.0, 1.0 + 0.0j),
     ],
 )
-def test_faddeeva_sample_values(faddeeva_input, faddeeva_expected_result):
-    assert allclose(voigt.faddeeva(faddeeva_input), faddeeva_expected_result)
+def test_faddeeva_sample_values(
+    faddeeva_sample_values_input, faddeeva_sample_values_expected_result
+):
+    assert allclose(
+        voigt.faddeeva(faddeeva_sample_values_input),
+        faddeeva_sample_values_expected_result,
+    )
 
 
 @pytest.mark.parametrize(
-    "voigt_input_delta_nu, voigt_input_doppler_width, voigt_input_gamma, voigt_expected_result",
+    "voigt_profile_input_delta_nu, voigt_profile_input_doppler_width, voigt_profile_input_gamma",
+    [
+        (0, 0, 0),
+        (1, 0, 0),
+        (0, 0, 1),
+        (1, 0, 1),
+    ],
+)
+def test_voigt_profile_division_by_zero(
+    voigt_profile_input_delta_nu,
+    voigt_profile_input_doppler_width,
+    voigt_profile_input_gamma,
+):
+    with pytest.raises(ZeroDivisionError):
+        _ = voigt.voigt_profile(
+            voigt_profile_input_delta_nu,
+            voigt_profile_input_doppler_width,
+            voigt_profile_input_gamma,
+        )
+
+
+@pytest.mark.parametrize(
+    "voigt_profile_input_delta_nu, voigt_profile_input_doppler_width, voigt_profile_input_gamma, voigt_profile_expected_result",
     [
         (0, 1, 0, 1 / sqrt(PI)),
         (0, 2, 0, 1 / (sqrt(PI) * 2)),
     ],
 )
-def test_voigt_sample_values(
-    voigt_input_delta_nu,
-    voigt_input_doppler_width,
-    voigt_input_gamma,
-    voigt_expected_result,
+def test_voigt_profile_sample_values(
+    voigt_profile_input_delta_nu,
+    voigt_profile_input_doppler_width,
+    voigt_profile_input_gamma,
+    voigt_profile_expected_result,
 ):
     assert allclose(
         voigt.voigt_profile(
-            voigt_input_delta_nu, voigt_input_doppler_width, voigt_input_gamma
+            voigt_profile_input_delta_nu,
+            voigt_profile_input_doppler_width,
+            voigt_profile_input_gamma,
         ),
-        voigt_expected_result,
+        voigt_profile_expected_result,
     )

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -2,6 +2,8 @@ import pytest
 from numpy import allclose, pi as PI
 from math import sqrt
 
+from stardis.opacities.voigt import faddeeva, voigt_profile
+
 
 @pytest.mark.parametrize(
     "faddeeva_sample_values_input, faddeeva_sample_values_expected_result",
@@ -13,8 +15,6 @@ from math import sqrt
 def test_faddeeva_sample_values(
     faddeeva_sample_values_input, faddeeva_sample_values_expected_result
 ):
-    from stardis.opacities.voigt import faddeeva
-
     assert allclose(
         faddeeva(faddeeva_sample_values_input),
         faddeeva_sample_values_expected_result,
@@ -46,8 +46,6 @@ def test_voigt_profile_division_by_zero(
     voigt_profile_division_by_zero_input_delta_nu,
     voigt_profile_division_by_zero_input_gamma,
 ):
-    from stardis.opacities.voigt import voigt_profile
-
     with pytest.raises(ZeroDivisionError):
         _ = voigt_profile(
             voigt_profile_division_by_zero_input_delta_nu,
@@ -69,8 +67,6 @@ def test_voigt_profile_sample_values_sample_values(
     voigt_profile_sample_values_input_gamma,
     voigt_profile_sample_values_expected_result,
 ):
-    from stardis.opacities.voigt import voigt_profile
-
     assert allclose(
         voigt_profile(
             voigt_profile_sample_values_input_delta_nu,

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -1,7 +1,6 @@
 import pytest
 from numpy import allclose, pi as PI
 from math import sqrt
-from stardis.opacities import voigt
 
 
 @pytest.mark.parametrize(
@@ -14,8 +13,10 @@ from stardis.opacities import voigt
 def test_faddeeva_sample_values(
     faddeeva_sample_values_input, faddeeva_sample_values_expected_result
 ):
+    from stardis.opacities.voigt import faddeeva
+
     assert allclose(
-        voigt.faddeeva(faddeeva_sample_values_input),
+        faddeeva(faddeeva_sample_values_input),
         faddeeva_sample_values_expected_result,
     )
 
@@ -34,8 +35,10 @@ def test_voigt_profile_division_by_zero(
     voigt_profile_input_doppler_width,
     voigt_profile_input_gamma,
 ):
+    from stardis.opacities.voigt import voigt_profile
+
     with pytest.raises(ZeroDivisionError):
-        _ = voigt.voigt_profile(
+        _ = voigt_profile(
             voigt_profile_input_delta_nu,
             voigt_profile_input_doppler_width,
             voigt_profile_input_gamma,
@@ -55,8 +58,10 @@ def test_voigt_profile_sample_values(
     voigt_profile_input_gamma,
     voigt_profile_expected_result,
 ):
+    from stardis.opacities.voigt import voigt_profile
+
     assert allclose(
-        voigt.voigt_profile(
+        voigt_profile(
             voigt_profile_input_delta_nu,
             voigt_profile_input_doppler_width,
             voigt_profile_input_gamma,

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -21,27 +21,19 @@ def test_faddeeva_sample_values(
     )
 
 
-@pytest.mark.parametrize(
-    "voigt_profile_input_delta_nu, voigt_profile_input_doppler_width, voigt_profile_input_gamma",
-    [
-        (0, 0, 0),
-        (1, 0, 0),
-        (0, 0, 1),
-        (1, 0, 1),
-    ],
-)
+@pytest.mark.parametrize("voigt_profile_division_by_zero_input_delta_nu", range(11))
+@pytest.mark.parametrize("voigt_profile_division_by_zero_input_gamma", range(11))
 def test_voigt_profile_division_by_zero(
-    voigt_profile_input_delta_nu,
-    voigt_profile_input_doppler_width,
-    voigt_profile_input_gamma,
+    voigt_profile_division_by_zero_input_delta_nu,
+    voigt_profile_division_by_zero_input_gamma,
 ):
     from stardis.opacities.voigt import voigt_profile
 
     with pytest.raises(ZeroDivisionError):
         _ = voigt_profile(
-            voigt_profile_input_delta_nu,
-            voigt_profile_input_doppler_width,
-            voigt_profile_input_gamma,
+            voigt_profile_division_by_zero_input_delta_nu,
+            0,
+            voigt_profile_division_by_zero_input_gamma,
         )
 
 

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -1,0 +1,36 @@
+import pytest
+from numpy import allclose, pi as PI
+from math import sqrt
+from stardis.opacities import voigt
+
+
+@pytest.mark.parametrize(
+    "faddeeva_input, faddeeva_expected_result",
+    [
+        (0, 1 + 0j),
+        (0.0, 1.0 + 0.0j),
+    ],
+)
+def test_faddeeva_sample_values(faddeeva_input, faddeeva_expected_result):
+    assert allclose(voigt.faddeeva(faddeeva_input), faddeeva_expected_result)
+
+
+@pytest.mark.parametrize(
+    "voigt_input_delta_nu, voigt_input_doppler_width, voigt_input_gamma, voigt_expected_result",
+    [
+        (0, 1, 0, 1 / sqrt(PI)),
+        (0, 2, 0, 1 / (sqrt(PI) * 2)),
+    ],
+)
+def test_voigt_sample_values(
+    voigt_input_delta_nu,
+    voigt_input_doppler_width,
+    voigt_input_gamma,
+    voigt_expected_result,
+):
+    assert allclose(
+        voigt.voigt_profile(
+            voigt_input_delta_nu, voigt_input_doppler_width, voigt_input_gamma
+        ),
+        voigt_expected_result,
+    )


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing` 

This pull request adds a few basic tests to the [`opacities.voigt`](https://github.com/tardis-sn/stardis/blob/main/stardis/opacities/voigt.py) module. The tests are parametrized to test several input values and also include tests to raise errors when a division by zero is attempted. 

### :pushpin: Resources

[How to parametrize pytest fixtures and test functions](https://docs.pytest.org/en/7.3.x/how-to/parametrize.html)

[Examples for parametrized test functions](https://docs.pytest.org/en/7.3.x/example/parametrize.html#paramexamples)


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] Tested locally


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
