### PR TITLE
Fix typo in raytrace

### DIFF
--- a/stardis/transport/base.py
+++ b/stardis/transport/base.py
@@ -152,7 +152,7 @@ def raytrace(stellar_model, alphas, tracing_nus, no_of_thetas=20):
     start_theta = dtheta / 2
     end_theta = (np.pi / 2) - (dtheta / 2)
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
-    F_nu = np.zeros(len(stellar_model.geometry, len(tracing_nus)))
+    F_nu = np.zeros((len(stellar_model.geometry.r), len(tracing_nus)))
 
     for theta in thetas:
         weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

This pull request fixes a minor typo in raytracing

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] `run_all()` runs

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request