### PR TITLE
Change abundances to mass fraction

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -45,13 +45,16 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
 
     adata = AtomData.from_hdf(config.atom_data)
 
+    # model
     stellar_model = read_marcs_to_fv(
         config.model.fname, adata, final_atomic_number=config.model.final_atomic_number
     )
     adata.prepare_atom_data(stellar_model.abundances.index.tolist())
 
+    # plasma
     stellar_plasma = create_stellar_plasma(stellar_model, adata)
 
+    # Below becomes radiation field
     alphas, gammas, doppler_widths = calc_alphas(
         stellar_plasma=stellar_plasma,
         stellar_model=stellar_model,
@@ -116,7 +119,6 @@ class STARDISOutput:
     def __init__(
         self, stellar_plasma, stellar_model, alphas, gammas, doppler_widths, F_nu, nus
     ):
-
         self.stellar_plasma = stellar_plasma
         self.stellar_model = stellar_model
         self.alphas = alphas

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -229,3 +229,83 @@ def read_marcs_model(fpath, gzipped=True):
     data = read_marcs_data(fpath, gzipped=gzipped)
 
     return MARCSModel(metadata, data)
+
+
+#THIS SHOULD NOT BE USED. JUST HERE TO SHOW WHAT STELLAR MODEL WILL LOOK LIKE 
+class StellarModel:
+    """
+    Class containing information about the stellar model.
+
+    Parameters
+    ----------
+    geometry : pandas.core.frame.DataFrame
+    chemical_mass_fractions : pandas.core.frame.DataFrame
+
+    Attributes
+    ----------
+    geometry : pandas.core.frame.DataFrame
+        Finite difference model DataFrame.
+    chemical_mass_fractions : pandas.core.frame.DataFrame
+        Chemical mass fraction DataFrame with all included elements and chemical_mass_fractions.
+    """
+
+    def __init__(self, geometry, chemical_mass_fractions):
+        self.geometry = geometry
+        self.chemical_mass_fractions = chemical_mass_fractions
+
+
+def raw_marcs_to_stellar_model(raw_marcs_model, atom_data, final_atomic_number=30, chemical_mass_fractions=None):
+    """
+    Reads MARCS model and produces a finite difference model.
+
+    Parameters
+    ----------
+    fpath : str
+        The filepath to the MARCS model.
+    atom_data : tardis.io.atom_data.base.AtomData
+    final_atomic_number : int, optional
+        Atomic number for the final element included in the model. Default
+        is 30.
+
+    Returns
+    -------
+    stardis.model.base.StellarModel
+    """
+
+    marcs_model = raw_marcs_model.data.copy()
+    marcs_model["tau_ref"] = 10 ** marcs_model["lgtaur"]
+    marcs_model["tau_500"] = 10 ** marcs_model["lgtau5"]
+
+    #NOTE: abundance_scale is now scaled_log_number_[element_number] and formatted by shell
+    if chemical_mass_fractions == None:
+        logging.warning('No abundance profile specified. Assuming uniform provided by the MARCS model file.')
+        marcs_chemical_mass_fractions = marcs_model.filter(regex='scaled_log_number').copy()
+    
+    if atom_data.atom_data.index.max() < final_atomic_number:
+        if len(marcs_chemical_mass_fractions.columns) > atom_data.atom_data.index.max():
+            logging.warning(f'Final model chemical number is {len(marcs_achemical_mass_fractions.columns)} while final atom data chemical number is {atom_data.atom_data.index.max()} and final atomic number requested is {final_atomic_number}.')
+
+    for atom_num, col in enumerate(marcs_chemical_mass_fractions.columns):
+        if atom_num >= len(atom_data.atom_data):
+            marcs_chemical_mass_fractions[f"mass_fraction_{atom_num+1}"] = np.nan
+        else:
+            marcs_chemical_mass_fractions[f"mass_fraction_{atom_num+1}"] = (10 ** marcs_chemical_mass_fractions[col]) * atom_data.atom_data.mass.iloc[atom_num] 
+        
+
+    marcs_chemical_mass_fractions[f"mass_fraction_{atom_num+1}"] = marcs_chemical_mass_fractions[f"mass_fraction_{atom_num+1}"] / marcs_chemical_mass_fractions.filter(regex='mass_fraction').sum(axis=1)
+
+    #Remove scaled log number columns - leaves only masses
+    dropped_cols = [c for c in marcs_chemical_mass_fractions.columns if 'scaled_log_number' in c]
+    marcs_chemical_mass_fractions.drop(columns=dropped_cols, inplace=True)
+    
+    #Divide by sum to leave mass densities
+    marcs_chemical_mass_fractions = marcs_chemical_mass_fractions.div(marcs_chemical_mass_fractions.sum(axis=1), axis=0)
+    marcs_chemical_mass_fractions = marcs_chemical_mass_fractions.iloc[:, : final_atomic_number]
+
+    marcs_model = marcs_model[['tau_ref', 'tau_500', 'depth', 't', 'density']]
+    marcs_model = marcs_model[::-1]
+
+    marcs_chemical_mass_fractions = marcs_chemical_mass_fractions[::-1]
+
+
+    return StellarModel(marcs_model, marcs_chemical_mass_fractions)

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -9,6 +9,8 @@ import logging
 
 from stardis.model.geometry.radial1d import Radial1DGeometry
 from stardis.model.composition.base import Composition
+
+# This import creates a circular import error.
 from stardis.model.base import StellarModel
 
 
@@ -44,7 +46,7 @@ class MARCSModel(object):
         """
         density = self.data.density.values * u.g / u.cm**3
         atomic_mass_fraction = self.convert_marcs_raw_abundances_to_mass_fractions(
-            self, atom_data, final_atomic_number=final_atomic_number
+            atom_data, final_atomic_number
         )
         return Composition(density, atomic_mass_fraction)
 
@@ -100,9 +102,7 @@ class MARCSModel(object):
 
         return marcs_chemical_mass_fractions
 
-    def to_stellar_model(
-        self, atom_data, final_atomic_number=30, chemical_mass_fractions=None
-    ):
+    def to_stellar_model(self, atom_data, final_atomic_number=30):
         """
         Produces a stellar model readable by stardis.
 
@@ -121,9 +121,8 @@ class MARCSModel(object):
         marcs_composition = self.to_composition(
             atom_data=atom_data, final_atomic_number=final_atomic_number
         )
-        temperatures = (
-            self.data.t.values * u.K
-        )  # This is a placeholder to carry temps for now
+        temperatures = self.data.t.values * u.K
+        # This is a placeholder to carry temps for now - Needed to pass into plasma and eventual also radiation field.
         # stellar model should have fv_geometry, abundances, boundary temps, geometry, composition for now
         return StellarModel(None, None, temperatures, marcs_geometry, marcs_composition)
 

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -10,7 +10,6 @@ import logging
 from stardis.model.geometry.radial1d import Radial1DGeometry
 from stardis.model.composition.base import Composition
 
-# This import creates a circular import error.
 from stardis.model.base import StellarModel
 
 

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -40,6 +40,7 @@ class MARCSModel(object):
         stardis.model.composition.base.Composition
         """
         density = self.data.density.values * u.g / u.cm**3
+        # THIS IS VERY WRONG. NEEDS TO BE FIXED WITH WORK FROM THE MASS FRACTION BRANCH
         atomic_mass_fraction = self.data[
             [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
         ].values

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -35,12 +35,18 @@ class MARCSModel(object):
         r = self.data.depth.values * u.cm
         return Radial1DGeometry(r)
 
-    def to_composition(self, atom_data, final_atomic_number=30):
+    def to_composition(self, atom_data, final_atomic_number):
         """
         Returns a stardis.model.composition.base.Composition object from the MARCS model.
 
+        Parameters
+        ----------
+        atom_data : tardis.io.atom_data.base.AtomData
+        final_atomic_number : int, optional
+            Atomic number for the final element included in the model.
+
         Returns
-        -------
+        ----------
         stardis.model.composition.base.Composition
         """
         density = self.data.density.values * u.g / u.cm**3
@@ -101,7 +107,7 @@ class MARCSModel(object):
 
         return marcs_chemical_mass_fractions
 
-    def to_stellar_model(self, atom_data, final_atomic_number=30):
+    def to_stellar_model(self, atom_data, final_atomic_number=118):
         """
         Produces a stellar model readable by stardis.
 
@@ -110,7 +116,7 @@ class MARCSModel(object):
         atom_data : tardis.io.atom_data.base.AtomData
         final_atomic_number : int, optional
             Atomic number for the final element included in the model. Default
-            is 30.
+            is 118, an abitrarily large atomic number so as not to truncate by default.
 
         Returns
         -------
@@ -136,6 +142,8 @@ def read_marcs_metadata(fpath, gzipped=True):
     ----------
     fpath : str
             Path to model file
+    gzipped : Bool
+            Whether or not the file is gzipped
 
     Returns
     -------
@@ -232,6 +240,8 @@ def read_marcs_data(fpath, gzipped=True):
     ----------
     fpath : str
             Path to model file
+    gzipped : Bool
+            Whether or not the file is gzipped
 
     Returns
     -------
@@ -298,6 +308,8 @@ def read_marcs_model(fpath, gzipped=True):
     ----------
     fpath : str
             Path to model file
+    gzipped : Bool
+            Whether or not the file is gzipped
 
     Returns
     -------

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -6,6 +6,7 @@ from astropy import units as u
 import numpy as np
 
 from stardis.model.geometry.radial1d import Radial1DGeometry
+from stardis.model.composition.base import Composition
 
 
 @dataclass
@@ -29,6 +30,21 @@ class MARCSModel(object):
         """
         r = self.data.depth.values * u.cm
         return Radial1DGeometry(r)
+
+    # def to_composition(self):
+    #     """
+    #     Returns a stardis.model.composition.base.Composition object from the MARCS model.
+
+    #     Returns
+    #     -------
+    #     stardis.model.composition.base.Composition
+    #     """
+    #     density = self.data.density.values * u.g / u.cm**3
+    #     # THIS IS VERY WRONG. NEEDS TO BE FIXED WITH WORK FROM THE MASS FRACTION BRANCH
+    #     atomic_mass_fraction = self.data[
+    #         [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
+    #     ].values
+    #     return Composition(density, atomic_mass_fraction)
 
 
 def read_marcs_metadata(fpath, gzipped=True):

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -31,20 +31,19 @@ class MARCSModel(object):
         r = self.data.depth.values * u.cm
         return Radial1DGeometry(r)
 
-    # def to_composition(self):
-    #     """
-    #     Returns a stardis.model.composition.base.Composition object from the MARCS model.
+    def to_composition(self):
+        """
+        Returns a stardis.model.composition.base.Composition object from the MARCS model.
 
-    #     Returns
-    #     -------
-    #     stardis.model.composition.base.Composition
-    #     """
-    #     density = self.data.density.values * u.g / u.cm**3
-    #     # THIS IS VERY WRONG. NEEDS TO BE FIXED WITH WORK FROM THE MASS FRACTION BRANCH
-    #     atomic_mass_fraction = self.data[
-    #         [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
-    #     ].values
-    #     return Composition(density, atomic_mass_fraction)
+        Returns
+        -------
+        stardis.model.composition.base.Composition
+        """
+        density = self.data.density.values * u.g / u.cm**3
+        atomic_mass_fraction = self.data[
+            [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
+        ].values
+        return Composition(density, atomic_mass_fraction)
 
 
 def read_marcs_metadata(fpath, gzipped=True):

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -79,16 +79,6 @@ class MARCSModel(object):
                     10 ** marcs_chemical_mass_fractions[col]
                 ) * atom_data.atom_data.mass.iloc[atom_num]
 
-        marcs_chemical_mass_fractions[
-            f"mass_fraction_{atom_num+1}"
-        ] = marcs_chemical_mass_fractions[
-            f"mass_fraction_{atom_num+1}"
-        ] / marcs_chemical_mass_fractions.filter(
-            regex="mass_fraction"
-        ).sum(
-            axis=1
-        )
-
         # Remove scaled log number columns - leaves only masses
         dropped_cols = [
             c for c in marcs_chemical_mass_fractions.columns if "scaled_log_number" in c

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -31,20 +31,20 @@ class MARCSModel(object):
         r = self.data.depth.values * u.cm
         return Radial1DGeometry(r)
 
-    def to_composition(self):
-        """
-        Returns a stardis.model.composition.base.Composition object from the MARCS model.
+    # def to_composition(self):
+    #     """
+    #     Returns a stardis.model.composition.base.Composition object from the MARCS model.
 
-        Returns
-        -------
-        stardis.model.composition.base.Composition
-        """
-        density = self.data.density.values * u.g / u.cm**3
-        # THIS IS VERY WRONG. NEEDS TO BE FIXED WITH WORK FROM THE MASS FRACTION BRANCH
-        atomic_mass_fraction = self.data[
-            [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
-        ].values
-        return Composition(density, atomic_mass_fraction)
+    #     Returns
+    #     -------
+    #     stardis.model.composition.base.Composition
+    #     """
+    #     density = self.data.density.values * u.g / u.cm**3
+    #     # THIS IS VERY WRONG. NEEDS TO BE FIXED WITH WORK FROM THE MASS FRACTION BRANCH
+    #     atomic_mass_fraction = self.data[
+    #         [f"scaled_log_number_fraction_{i+1}" for i in range(30)]
+    #     ].values
+    #     return Composition(density, atomic_mass_fraction)
 
 
 def read_marcs_metadata(fpath, gzipped=True):

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -59,6 +59,7 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
     marcs_raw_model = read_marcs_model(fpath, gzipped=False)
     geometry = marcs_raw_model.to_geometry()
     # composition = marcs_raw_model.to_composition()
+    composition = None
 
     marcs_model1 = pd.read_csv(
         fpath, skiprows=24, nrows=56, delim_whitespace=True, index_col="k"

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 
-from astropy import units as u, constants as const
 from stardis.io.model.marcs import read_marcs_model
 
 
@@ -15,6 +14,7 @@ class StellarModel:
     abundances : pandas.core.frame.DataFrame
     boundary_temps : numpy.ndarray
     geometry : stardis.model.geometry
+    composition : stardis.model.composition.base.Composition
 
     Attributes
     ----------
@@ -26,13 +26,16 @@ class StellarModel:
         Temperatures in K of all shell boundaries. Note that array is transposed.
     geometry : stardis.model.geometry
         Geometry of the model.
+    composition : stardis.model.composition.base.Composition
+        Composition of the model. Includes density and atomic mass fractions.
     """
 
-    def __init__(self, fv_geometry, abundances, boundary_temps, geometry):
+    def __init__(self, fv_geometry, abundances, boundary_temps, geometry, composition):
         self.fv_geometry = fv_geometry
         self.abundances = abundances
         self.boundary_temps = boundary_temps
         self.geometry = geometry
+        self.composition = composition
 
 
 def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
@@ -55,6 +58,8 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
 
     marcs_raw_model = read_marcs_model(fpath, gzipped=False)
     geometry = marcs_raw_model.to_geometry()
+    # composition = marcs_raw_model.to_composition()
+    composition = None
 
     marcs_model1 = pd.read_csv(
         fpath, skiprows=24, nrows=56, delim_whitespace=True, index_col="k"
@@ -110,4 +115,6 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
         marcs_abundances_all[i] = marcs_abundances["mass_abundance"]
     marcs_abundances_all = marcs_abundances_all[:final_atomic_number]
 
-    return StellarModel(marcs_model_fv, marcs_abundances_all, boundary_temps, geometry)
+    return StellarModel(
+        marcs_model_fv, marcs_abundances_all, boundary_temps, geometry, composition
+    )

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -58,8 +58,7 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
 
     marcs_raw_model = read_marcs_model(fpath, gzipped=False)
     geometry = marcs_raw_model.to_geometry()
-    # composition = marcs_raw_model.to_composition()
-    composition = None
+    composition = marcs_raw_model.to_composition()
 
     marcs_model1 = pd.read_csv(
         fpath, skiprows=24, nrows=56, delim_whitespace=True, index_col="k"

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import numpy as np
 
-from stardis.io.model.marcs import read_marcs_model
-
 
 class StellarModel:
     """
@@ -56,10 +54,14 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
     stardis.model.base.StellarModel
     """
 
+    # This is a hacky workaround to avoid circular imports. Should be fixed when we remove the read_marcs_to_fv function.
+    from stardis.io.model.marcs import read_marcs_model
+
     marcs_raw_model = read_marcs_model(fpath, gzipped=False)
     geometry = marcs_raw_model.to_geometry()
-    # composition = marcs_raw_model.to_composition()
-    composition = None
+    composition = marcs_raw_model.to_composition(
+        atom_data=atom_data, final_atomic_number=final_atomic_number
+    )
 
     marcs_model1 = pd.read_csv(
         fpath, skiprows=24, nrows=56, delim_whitespace=True, index_col="k"

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -58,7 +58,7 @@ def read_marcs_to_fv(fpath, atom_data, final_atomic_number=30):
 
     marcs_raw_model = read_marcs_model(fpath, gzipped=False)
     geometry = marcs_raw_model.to_geometry()
-    composition = marcs_raw_model.to_composition()
+    # composition = marcs_raw_model.to_composition()
 
     marcs_model1 = pd.read_csv(
         fpath, skiprows=24, nrows=56, delim_whitespace=True, index_col="k"

--- a/stardis/model/composition/base.py
+++ b/stardis/model/composition/base.py
@@ -5,9 +5,9 @@ class Composition:
     Parameters
     ----------
     density : astropy.units.quantity.Quantity
-        Density of the plasma
+        Density of the plasma at each depth point
     atomic_mass_fraction : pandas.core.frame.DataFrame
-        Mass fraction of each element
+        Mass fraction of each element at each depth point
 
 
 

--- a/stardis/model/composition/base.py
+++ b/stardis/model/composition/base.py
@@ -1,0 +1,18 @@
+class Composition:
+    """
+    Holds composition information
+
+    Parameters
+    ----------
+    density : astropy.units.quantity.Quantity
+        Density of the plasma
+    atomic_mass_fraction : pandas.core.frame.DataFrame
+        Mass fraction of each element
+
+
+
+    """
+
+    def __init__(self, density, atomic_mass_fraction):
+        self.density = density
+        self.atomic_mass_fraction = atomic_mass_fraction


### PR DESCRIPTION
### :pencil: Description

**Type:** | :rocket: `feature` | :roller_coaster: `infrastructure`

This PR should probably have been broken into two pull requests. It does two primary things.

marcs.py has been changed to add a to_composition() method that uses the Composition class added in [PR 103 ](https://github.com/tardis-sn/stardis/pull/103). It also adds a to_stellar_model() method that outputs a geometry, composition, and temperatures, though this method is currently not called anywhere. 

The second thing this PR does is alter the StellarModel class to hold the composition, allowing for the previous to_stellar_model() method to exist, and updates read_marcs_to_fv() correctly to handle this change. 

The read_marcs_model import in stardis/model/base.py was moved inside read_marcs_to_fv() to avoid a circular import. This is necessary for now, but should not persist because we aim to remove the read_marcs_to_fv() function altogether and just move over to the new model reader that can directly output a stellar model that can be correctly handled by stardis. 

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Tested the quickstart notebook locally to make sure the code still runs and produces the expected output. 


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
