### PR TITLE
Add CUDA GPU JIT compilation to `faddeeva()`

### DIFF
--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -30,7 +30,7 @@ def test_faddeeva_sample_values(
     not GPUs_available, reason="No GPU is available to test CUDA function"
 )
 @pytest.mark.parametrize(
-    "faddeeva_sample_values_input, faddeeva_sample_values_expected_result",
+    "faddeeva_cuda_sample_values_input, faddeeva_cuda_sample_values_expected_result",
     [
         # (0, 1 + 0j),
         # (0.0, 1.0 + 0.0j),
@@ -39,18 +39,18 @@ def test_faddeeva_sample_values(
     ],
 )
 def test_faddeeva_cuda_sample_values(
-    faddeeva_sample_values_input, faddeeva_sample_values_expected_result
+    faddeeva_cuda_sample_values_input, faddeeva_cuda_sample_values_expected_result
 ):
-    test_values = cuda.to_device(faddeeva_sample_values_input)
+    test_values = cuda.to_device(faddeeva_cuda_sample_values_input)
     result_values = cuda.device_array_like(test_values)
 
-    length = len(faddeeva_sample_values_input)
+    length = len(faddeeva_cuda_sample_values_input)
 
     faddeeva_cuda.forall(length)(result_values, test_values)
 
     assert np.allclose(
         result_values.copy_to_host(),
-        faddeeva_sample_values_expected_result,
+        faddeeva_cuda_sample_values_expected_result,
     )
 
 

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -70,6 +70,14 @@ def test_faddeeva_cuda_unwrapped_sample_values(
         # (0.0, 1.0 + 0.0j),
         (np.array([0.0]), np.array([1.0 + 0.0j])),
         (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
+        (
+            cuda.device_array_like(np.array([0, 0], dtype=complex)),
+            np.array([1 + 0j, 1 + 0j]),
+        ),
+        # (
+        #     cuda.device_array_like(np.array([0, 0], dtype=float)),
+        #     np.array([1 + 0j, 1 + 0j]),
+        # ),
     ],
 )
 def test_faddeeva_cuda_wrapped_sample_values(
@@ -80,6 +88,23 @@ def test_faddeeva_cuda_wrapped_sample_values(
         faddeeva_cuda(faddeeva_cuda_wrapped_sample_values_input),
         faddeeva_cuda_wrapped_sample_values_expected_result,
     )
+
+
+@pytest.mark.skipif(
+    not GPUs_available, reason="No GPU is available to test CUDA function"
+)
+@pytest.mark.parametrize(
+    "faddeeva_cuda_wrapped_noncomplex_input_input",
+    [
+        cuda.device_array_like(np.array([0, 0], dtype=int)),
+        cuda.device_array_like(np.array([0, 0], dtype=float)),
+    ],
+)
+def test_faddeeva_cuda_wrapped_noncomplex_input(
+    faddeeva_cuda_wrapped_noncomplex_input_input,
+):
+    with pytest.raises(TypeError):
+        _ = faddeeva_cuda(faddeeva_cuda_wrapped_noncomplex_input_input)
 
 
 test_voigt_profile_division_by_zero_test_values = [

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -1,8 +1,11 @@
 import pytest
-from numpy import allclose, pi as PI
+import numpy as np
 from math import sqrt
+from numba import cuda
+from stardis.opacities.voigt import faddeeva, faddeeva_cuda, voigt_profile
 
-from stardis.opacities.voigt import faddeeva, voigt_profile
+# Test cases must also take into account use of a GPU to run. If there is no GPU then the test cases will fail.
+GPUs_available = cuda.is_available()
 
 
 @pytest.mark.parametrize(
@@ -10,13 +13,38 @@ from stardis.opacities.voigt import faddeeva, voigt_profile
     [
         (0, 1 + 0j),
         (0.0, 1.0 + 0.0j),
+        (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
     ],
 )
 def test_faddeeva_sample_values(
     faddeeva_sample_values_input, faddeeva_sample_values_expected_result
 ):
-    assert allclose(
+    assert np.allclose(
         faddeeva(faddeeva_sample_values_input),
+        faddeeva_sample_values_expected_result,
+    )
+
+
+@pytest.mark.skipif(
+    not GPUs_available, reason="No GPU is available to test CUDA function"
+)
+@pytest.mark.parametrize(
+    "faddeeva_sample_values_input, faddeeva_sample_values_expected_result",
+    [
+        (0, 1 + 0j),
+        (0.0, 1.0 + 0.0j),
+        (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
+    ],
+)
+def test_faddeeva_cuda_sample_values(
+    faddeeva_sample_values_input, faddeeva_sample_values_expected_result
+):
+    test_values = cuda.to_device(faddeeva_sample_values_input)
+    result_values = cuda.device_array_like(test_values)
+
+    faddeeva_cuda.forall(len(test_values))(result_values, test_values)
+    assert np.allclose(
+        result_values.copy_to_host,
         faddeeva_sample_values_expected_result,
     )
 
@@ -57,8 +85,8 @@ def test_voigt_profile_division_by_zero(
 @pytest.mark.parametrize(
     "voigt_profile_sample_values_input_delta_nu, voigt_profile_sample_values_input_doppler_width, voigt_profile_sample_values_input_gamma, voigt_profile_sample_values_expected_result",
     [
-        (0, 1, 0, 1 / sqrt(PI)),
-        (0, 2, 0, 1 / (sqrt(PI) * 2)),
+        (0, 1, 0, 1 / sqrt(np.pi)),
+        (0, 2, 0, 1 / (sqrt(np.pi) * 2)),
     ],
 )
 def test_voigt_profile_sample_values_sample_values(
@@ -67,7 +95,7 @@ def test_voigt_profile_sample_values_sample_values(
     voigt_profile_sample_values_input_gamma,
     voigt_profile_sample_values_expected_result,
 ):
-    assert allclose(
+    assert np.allclose(
         voigt_profile(
             voigt_profile_sample_values_input_delta_nu,
             voigt_profile_sample_values_input_doppler_width,

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -13,6 +13,7 @@ GPUs_available = cuda.is_available()
     [
         (0, 1 + 0j),
         (0.0, 1.0 + 0.0j),
+        (np.array([0.0]), np.array([1.0 + 0.0j])),
         (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
     ],
 )
@@ -31,9 +32,10 @@ def test_faddeeva_sample_values(
 @pytest.mark.parametrize(
     "faddeeva_sample_values_input, faddeeva_sample_values_expected_result",
     [
-        (0, 1 + 0j),
-        (0.0, 1.0 + 0.0j),
-        (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
+        # (0, 1 + 0j),
+        # (0.0, 1.0 + 0.0j),
+        (np.array([0.0], dtype=complex), np.array([1.0 + 0.0j])),
+        (np.array([0, 0], dtype=complex), np.array([1 + 0j, 1 + 0j])),
     ],
 )
 def test_faddeeva_cuda_sample_values(
@@ -42,9 +44,12 @@ def test_faddeeva_cuda_sample_values(
     test_values = cuda.to_device(faddeeva_sample_values_input)
     result_values = cuda.device_array_like(test_values)
 
-    faddeeva_cuda.forall(len(test_values))(result_values, test_values)
+    length = len(faddeeva_sample_values_input)
+
+    faddeeva_cuda.forall(length)(result_values, test_values)
+
     assert np.allclose(
-        result_values.copy_to_host,
+        result_values.copy_to_host(),
         faddeeva_sample_values_expected_result,
     )
 

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from math import sqrt
 from numba import cuda
-import cupy as cp
+
 from stardis.opacities.voigt import (
     faddeeva,
     _faddeeva_cuda,
@@ -12,6 +12,9 @@ from stardis.opacities.voigt import (
 
 # Test cases must also take into account use of a GPU to run. If there is no GPU then the test cases will fail.
 GPUs_available = cuda.is_available()
+
+if GPUs_available:
+    import cupy as cp
 
 
 @pytest.mark.parametrize(

--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -37,8 +37,6 @@ def test_faddeeva_sample_values(
 @pytest.mark.parametrize(
     "faddeeva_cuda_unwrapped_sample_values_input, faddeeva_cuda_unwrapped_sample_values_expected_result",
     [
-        # (0, 1 + 0j),
-        # (0.0, 1.0 + 0.0j),
         (np.array([0.0], dtype=complex), np.array([1.0 + 0.0j])),
         (np.array([0, 0], dtype=complex), np.array([1 + 0j, 1 + 0j])),
     ],
@@ -64,29 +62,43 @@ def test_faddeeva_cuda_unwrapped_sample_values(
     not GPUs_available, reason="No GPU is available to test CUDA function"
 )
 @pytest.mark.parametrize(
-    "faddeeva_cuda_wrapped_sample_values_input, faddeeva_cuda_wrapped_sample_values_expected_result",
+    "faddeeva_cuda_wrapped_sample_numpy_values_input, faddeeva_cuda_wrapped_sample_numpy_values_expected_result",
     [
-        # (0, 1 + 0j),
-        # (0.0, 1.0 + 0.0j),
         (np.array([0.0]), np.array([1.0 + 0.0j])),
         (np.array([0, 0]), np.array([1 + 0j, 1 + 0j])),
-        (
-            cuda.device_array_like(np.array([0, 0], dtype=complex)),
-            np.array([1 + 0j, 1 + 0j]),
-        ),
-        # (
-        #     cuda.device_array_like(np.array([0, 0], dtype=float)),
-        #     np.array([1 + 0j, 1 + 0j]),
-        # ),
     ],
 )
-def test_faddeeva_cuda_wrapped_sample_values(
-    faddeeva_cuda_wrapped_sample_values_input,
-    faddeeva_cuda_wrapped_sample_values_expected_result,
+def test_faddeeva_cuda_wrapped_sample_numpy_values(
+    faddeeva_cuda_wrapped_sample_numpy_values_input,
+    faddeeva_cuda_wrapped_sample_numpy_values_expected_result,
 ):
     assert np.allclose(
-        faddeeva_cuda(faddeeva_cuda_wrapped_sample_values_input),
-        faddeeva_cuda_wrapped_sample_values_expected_result,
+        faddeeva_cuda(faddeeva_cuda_wrapped_sample_numpy_values_input),
+        faddeeva_cuda_wrapped_sample_numpy_values_expected_result,
+    )
+
+
+@pytest.mark.skipif(
+    not GPUs_available, reason="No GPU is available to test CUDA function"
+)
+@pytest.mark.parametrize(
+    "faddeeva_cuda_wrapped_sample_cuda_values_input, faddeeva_cuda_wrapped_sample_cuda_values_expected_result",
+    [
+        (
+            np.array([0, 0], dtype=complex),
+            np.array([1 + 0j, 1 + 0j]),
+        ),
+    ],
+)
+def test_faddeeva_cuda_wrapped_sample_cuda_values(
+    faddeeva_cuda_wrapped_sample_cuda_values_input,
+    faddeeva_cuda_wrapped_sample_cuda_values_expected_result,
+):
+    assert np.allclose(
+        faddeeva_cuda(
+            cuda.device_array_like(faddeeva_cuda_wrapped_sample_cuda_values_input)
+        ),
+        faddeeva_cuda_wrapped_sample_cuda_values_expected_result,
     )
 
 
@@ -96,15 +108,17 @@ def test_faddeeva_cuda_wrapped_sample_values(
 @pytest.mark.parametrize(
     "faddeeva_cuda_wrapped_noncomplex_input_input",
     [
-        cuda.device_array_like(np.array([0, 0], dtype=int)),
-        cuda.device_array_like(np.array([0, 0], dtype=float)),
+        np.array([0, 0], dtype=int),
+        np.array([0, 0], dtype=float),
     ],
 )
 def test_faddeeva_cuda_wrapped_noncomplex_input(
     faddeeva_cuda_wrapped_noncomplex_input_input,
 ):
     with pytest.raises(TypeError):
-        _ = faddeeva_cuda(faddeeva_cuda_wrapped_noncomplex_input_input)
+        _ = faddeeva_cuda(
+            cuda.device_array_like(faddeeva_cuda_wrapped_noncomplex_input_input)
+        )
 
 
 test_voigt_profile_division_by_zero_test_values = [

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -83,12 +83,21 @@ def faddeeva(z):
 
 
 @cuda.jit
-def faddeeva_cuda(res, z):
+def _faddeeva_cuda(res, z):
     tid = cuda.grid(1)
     size = len(z)
 
     if tid < size:
         res[tid] = _faddeeva(z[tid])
+
+
+def faddeeva_cuda(z):
+    size = len(z)
+    z = z.astype(complex)
+    res = cuda.device_array_like(z)
+
+    _faddeeva_cuda.forall(size)(res, z)
+    return res.copy_to_host()
 
 
 @numba.njit

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -93,7 +93,12 @@ def _faddeeva_cuda(res, z):
 
 def faddeeva_cuda(z):
     size = len(z)
-    z = z.astype(complex)
+    if hasattr(z, "astype"):
+        z = z.astype(complex)
+    if not np.iscomplexobj(z):
+        raise TypeError(
+            f"Faddeeva with cuda only works with complex arguments. Expected any complex datatyep and instead got {z.dtype}."
+        )
     res = cuda.device_array_like(z)
 
     _faddeeva_cuda.forall(size)(res, z)

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -74,6 +74,15 @@ def faddeeva(z):
     return w
 
 
+@cuda.jit
+def faddeeva_cuda(res, z):
+    tid = cuda.grid(1)
+    size = len(z)
+
+    if tid < size:
+        res[tid] = faddeeva(z[tid])
+
+
 @numba.njit
 def voigt_profile(delta_nu, doppler_width, gamma):
     """

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -5,7 +5,8 @@ from numba import cuda
 SQRT_PI = np.sqrt(np.pi)
 
 
-@numba.njit
+# @numba.njit
+@numba.vectorize(nopython=True)
 def faddeeva(z):
     """
     The Faddeeva function. Code adapted from

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numba
+from numba import cuda
 
 
 @numba.njit

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -2,6 +2,8 @@ import numpy as np
 import numba
 from numba import cuda
 
+SQRT_PI = np.sqrt(np.pi)
+
 
 @numba.njit
 def faddeeva(z):
@@ -21,13 +23,13 @@ def faddeeva(z):
 
     if s > 15.0:
         # region I
-        w = 1j * 1 / np.sqrt(np.pi) * z / (z**2 - 0.5)
+        w = 1j * 1 / SQRT_PI * z / (z**2 - 0.5)
 
     elif s > 5.5:
         # region II
         w = (
             1j
-            * (z * (z**2 * 1 / np.sqrt(np.pi) - 1.4104739589))
+            * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
             / (0.75 + z**2 * (z**2 - 3.0))
         )
 
@@ -105,5 +107,5 @@ def voigt_profile(delta_nu, doppler_width, gamma):
         Value of Voigt profile.
     """
     z = (delta_nu + (gamma / (4 * np.pi)) * 1j) / doppler_width
-    phi = np.real(faddeeva(z)) / (np.sqrt(np.pi) * doppler_width)
+    phi = np.real(faddeeva(z)) / (SQRT_PI * doppler_width)
     return phi

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -97,7 +97,7 @@ def _faddeeva_cuda(res, z):
         res[tid] = _faddeeva(z[tid])
 
 
-def faddeeva_cuda(z, nthreads=256, ret_np_ndarray=True):
+def faddeeva_cuda(z, nthreads=256, ret_np_ndarray=False):
     size = len(z)
     nblocks = 1 + (size // nthreads)
     z = cp.asarray(z, dtype=complex)

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -25,6 +25,7 @@ def _faddeeva(z):
     -------
     w : complex
     """
+    z = complex(z)
     x = float(z.real)
     y = float(z.imag)
     t = y - 1j * x

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -1,8 +1,12 @@
 import numpy as np
 import numba
 from numba import cuda
-import cupy as cp
 import cmath
+
+GPUs_available = cuda.is_available()
+
+if GPUs_available:
+    import cupy as cp
 
 SQRT_PI = np.sqrt(np.pi, dtype=float)
 

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -91,7 +91,7 @@ def faddeeva(z):
 @cuda.jit
 def _faddeeva_cuda(res, z):
     tid = cuda.grid(1)
-    size = len(z)
+    size = len(res)
 
     if tid < size:
         res[tid] = _faddeeva(z[tid])


### PR DESCRIPTION
### :pencil: Description

**Type:**  :rocket: `feature`

This pull request implements CUDA JITting for Faddeeva. The non-CUDA version of Faddeeva is also refactored. 

The associated tests are included.

This pull request should be merged (hopefully immediately) ***after*** pull request #110 

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request