### PR TITLE
Change sphinx docs to pydata theme

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -46,7 +46,7 @@ jobs:
         id: install-stardis
         # shell: bash -l {0}
         run: |
-          python setup.py develop
+          pip install -e .[docs]
 
       - name: Make Sphinx HTML
         id: make-sphinx-html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ intersphinx_mapping = {"https://docs.python.org/": None}
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+html_theme = "pydata_sphinx_theme"  # "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ test =
 docs =
     sphinx
     sphinx-automodapi
+    pydata-sphinx-theme
 
 [tool:pytest]
 testpaths = "stardis" "docs"


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation`

This pull request changes the sphinx theme to the pydata theme

Installs pydata automatically using ``$ pip install -e .[docs]``


### :pushpin: Resources

[Here is a preview](https://smokestacklightnin.github.io/stardis/branch/docs/theme/change-to-pydata/)

[Here is the current official STARDIS documentation for comparison](https://tardis-sn.github.io/stardis/)

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes