### PR TITLE
add arg to the config_schema.yml file for gzipped and hook up in run_stardis

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -48,10 +48,9 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
     if config.model.type == "marcs":
         from stardis.io.model.marcs import read_marcs_model
 
-        # FIX THIS BY ADDING AN OPTIONAL GZIPPED ARGUMENT TO THE CONFIG
         raw_marcs_model = read_marcs_model(
             config.model.fname, gzipped=config.model.gzipped
-        )  # Need to add gzipped to config
+        )
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number
         )

--- a/stardis/base.py
+++ b/stardis/base.py
@@ -50,7 +50,7 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
 
         # FIX THIS BY ADDING AN OPTIONAL GZIPPED ARGUMENT TO THE CONFIG
         raw_marcs_model = read_marcs_model(
-            config.model.fname, gzipped=False
+            config.model.fname, gzipped=config.model.gzipped
         )  # Need to add gzipped to config
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -16,10 +16,14 @@ properties:
                 - marcs
             fname:
                 type: string
+            gzipped:
+                type: boolean
+                default: false            
             final_atomic_number:
                 type: number
                 multipleOf: 1
                 default: 30
+
         required:
         - type
         - fname


### PR DESCRIPTION
Allows the config to take a gzipped argument in model and passes that to the model reader.

This allows the config to point to any plane-parallel model obtained from https://marcs.oreme.org/

