### PR TITLE
Add CUDA JIT to `calc_n_effective()`

### DIFF
--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -70,7 +70,7 @@ def calc_doppler_width_cuda(
     temperature,
     atomic_mass,
     nthreads=256,
-    ret_np_ndarray=True,
+    ret_np_ndarray=False,
     dtype=float,
 ):
     arg_list = (

--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -32,10 +32,16 @@ def _calc_doppler_width(nu_line, temperature, atomic_mass):
     -------
     float
     """
+    nu_line, temperature, atomic_mass = (
+        float(nu_line),
+        float(temperature),
+        float(atomic_mass),
+    )
+
     return (
         nu_line
         / SPEED_OF_LIGHT
-        * math.sqrt(2 * BOLTZMANN_CONSTANT * temperature / atomic_mass)
+        * math.sqrt(2.0 * BOLTZMANN_CONSTANT * temperature / atomic_mass)
     )
 
 

--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -149,7 +149,7 @@ def calc_n_effective_cuda(
     ionization_energy,
     level_energy,
     nthreads=256,
-    ret_np_ndarray=True,
+    ret_np_ndarray=False,
     dtype=float,
 ):
     arg_list = (

--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -97,7 +97,7 @@ def calc_doppler_width_cuda(
 
 
 @numba.njit
-def calc_n_effective(ion_number, ionization_energy, level_energy):
+def _calc_n_effective(ion_number, ionization_energy, level_energy):
     """
     Calculates the effective principal quantum number of an energy level.
 
@@ -114,7 +114,17 @@ def calc_n_effective(ion_number, ionization_energy, level_energy):
     -------
     float
     """
-    return np.sqrt(RYDBERG_ENERGY / (ionization_energy - level_energy)) * ion_number
+    ion_number, ionization_energy, level_energy = (
+        int(ion_number),
+        float(ionization_energy),
+        float(level_energy),
+    )
+    return math.sqrt(RYDBERG_ENERGY / (ionization_energy - level_energy)) * ion_number
+
+
+@numba.vectorize(nopython=True)
+def calc_n_effective(ion_number, ionization_energy, level_energy):
+    return _calc_n_effective(ion_number, ionization_energy, level_energy)
 
 
 @numba.njit

--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy import constants as const
+import math
 import numba
 
 
@@ -13,7 +14,7 @@ VACUUM_ELECTRIC_PERMITTIVITY = 1 / (4 * np.pi)
 
 
 @numba.njit
-def calc_doppler_width(nu_line, temperature, atomic_mass):
+def _calc_doppler_width(nu_line, temperature, atomic_mass):
     """
     Calculates doppler width.
     https://ui.adsabs.harvard.edu/abs/2003rtsa.book.....R/
@@ -34,8 +35,13 @@ def calc_doppler_width(nu_line, temperature, atomic_mass):
     return (
         nu_line
         / SPEED_OF_LIGHT
-        * np.sqrt(2 * BOLTZMANN_CONSTANT * temperature / atomic_mass)
+        * math.sqrt(2 * BOLTZMANN_CONSTANT * temperature / atomic_mass)
     )
+
+
+@numba.vectorize(nopython=True)
+def calc_doppler_width(nu_line, temperature, atomic_mass):
+    return _calc_doppler_width(nu_line, temperature, atomic_mass)
 
 
 @numba.njit

--- a/stardis/opacities/broadening.py
+++ b/stardis/opacities/broadening.py
@@ -124,7 +124,55 @@ def _calc_n_effective(ion_number, ionization_energy, level_energy):
 
 @numba.vectorize(nopython=True)
 def calc_n_effective(ion_number, ionization_energy, level_energy):
-    return _calc_n_effective(ion_number, ionization_energy, level_energy)
+    return _calc_n_effective(
+        ion_number,
+        ionization_energy,
+        level_energy,
+    )
+
+
+@cuda.jit
+def _calc_n_effective_cuda(res, ion_number, ionization_energy, level_energy):
+    tid = cuda.grid(1)
+    size = len(res)
+
+    if tid < size:
+        res[tid] = _calc_n_effective(
+            ion_number[tid],
+            ionization_energy[tid],
+            level_energy[tid],
+        )
+
+
+def calc_n_effective_cuda(
+    ion_number,
+    ionization_energy,
+    level_energy,
+    nthreads=256,
+    ret_np_ndarray=True,
+    dtype=float,
+):
+    arg_list = (
+        ion_number,
+        ionization_energy,
+        level_energy,
+    )
+
+    shortest_arg_idx = np.argmin(map(len, arg_list))
+    size = len(arg_list[shortest_arg_idx])
+
+    nblocks = 1 + (size // nthreads)
+
+    arg_list = tuple(map(lambda v: cp.array(v, dtype=dtype), arg_list))
+
+    res = cp.empty_like(arg_list[shortest_arg_idx], dtype=dtype)
+
+    _calc_n_effective_cuda[nblocks, nthreads](
+        res,
+        *arg_list,
+    )
+
+    return cp.asnumpy(res) if ret_np_ndarray else res
 
 
 @numba.njit

--- a/stardis/opacities/tests/test_broadening.py
+++ b/stardis/opacities/tests/test_broadening.py
@@ -3,7 +3,11 @@ import numpy as np
 from astropy import constants as const
 from numba import cuda
 
-from stardis.opacities.broadening import calc_doppler_width, _calc_doppler_width_cuda
+from stardis.opacities.broadening import (
+    calc_doppler_width,
+    _calc_doppler_width_cuda,
+    calc_doppler_width_cuda,
+)
 
 GPUs_available = cuda.is_available()
 
@@ -92,4 +96,35 @@ def test_calc_doppler_width_cuda_unwrapped_sample_values(
     assert np.allclose(
         cp.asnumpy(result_values),
         calc_doppler_width_cuda_unwrapped_sample_values_expected_result,
+    )
+
+
+@pytest.mark.skipif(
+    not GPUs_available, reason="No GPU is available to test CUDA function"
+)
+@pytest.mark.parametrize(
+    "calc_doppler_width_cuda_sample_values_input_nu_line, calc_doppler_width_cuda_sample_values_input_temperature, calc_doppler_width_cuda_sample_values_input_atomic_mass, calc_doppler_width_cuda_wrapped_sample_cuda_values_expected_result",
+    [
+        (
+            np.array(2 * [SPEED_OF_LIGHT]),
+            np.array(2 * [0.5]),
+            np.array(2 * [BOLTZMANN_CONSTANT]),
+            np.array(2 * [1.0]),
+        ),
+    ],
+)
+def test_calc_doppler_width_cuda_wrapped_sample_cuda_values(
+    calc_doppler_width_cuda_sample_values_input_nu_line,
+    calc_doppler_width_cuda_sample_values_input_temperature,
+    calc_doppler_width_cuda_sample_values_input_atomic_mass,
+    calc_doppler_width_cuda_wrapped_sample_cuda_values_expected_result,
+):
+    arg_list = (
+        calc_doppler_width_cuda_sample_values_input_nu_line,
+        calc_doppler_width_cuda_sample_values_input_temperature,
+        calc_doppler_width_cuda_sample_values_input_atomic_mass,
+    )
+    assert np.allclose(
+        calc_doppler_width_cuda(*map(cp.asarray, arg_list)),
+        calc_doppler_width_cuda_wrapped_sample_cuda_values_expected_result,
     )

--- a/stardis/opacities/tests/test_broadening.py
+++ b/stardis/opacities/tests/test_broadening.py
@@ -7,6 +7,7 @@ from stardis.opacities.broadening import (
     calc_doppler_width,
     _calc_doppler_width_cuda,
     calc_doppler_width_cuda,
+    calc_n_effective,
 )
 
 GPUs_available = cuda.is_available()
@@ -127,4 +128,37 @@ def test_calc_doppler_width_cuda_wrapped_sample_cuda_values(
     assert np.allclose(
         calc_doppler_width_cuda(*map(cp.asarray, arg_list)),
         calc_doppler_width_cuda_wrapped_sample_cuda_values_expected_result,
+    )
+
+
+@pytest.mark.parametrize(
+    "calc_n_effective_sample_values_input_ion_number,calc_n_effective_sample_values_input_ionization_energy,calc_n_effective_sample_values_input_level_energy, calc_n_effective_sample_values_expected_result",
+    [
+        (
+            1.0,
+            RYDBERG_ENERGY,
+            0,
+            1.0,
+        ),
+        (
+            np.array(2 * [1.0]),
+            np.array(2 * [RYDBERG_ENERGY]),
+            np.array(2 * [0]),
+            np.array(2 * [1.0]),
+        ),
+    ],
+)
+def test_calc_n_effective_sample_values(
+    calc_n_effective_sample_values_input_ion_number,
+    calc_n_effective_sample_values_input_ionization_energy,
+    calc_n_effective_sample_values_input_level_energy,
+    calc_n_effective_sample_values_expected_result,
+):
+    assert np.allclose(
+        calc_n_effective(
+            calc_n_effective_sample_values_input_ion_number,
+            calc_n_effective_sample_values_input_ionization_energy,
+            calc_n_effective_sample_values_input_level_energy,
+        ),
+        calc_n_effective_sample_values_expected_result,
     )

--- a/stardis/opacities/tests/test_broadening.py
+++ b/stardis/opacities/tests/test_broadening.py
@@ -1,10 +1,10 @@
 import pytest
-from numpy import allclose, pi as PI
+import numpy as np
 from astropy import constants as const
 
 from stardis.opacities.broadening import calc_doppler_width
 
-
+PI = np.pi
 SPEED_OF_LIGHT = const.c.cgs.value
 BOLTZMANN_CONSTANT = const.k_B.cgs.value
 PLANCK_CONSTANT = const.h.cgs.value
@@ -17,8 +17,18 @@ VACUUM_ELECTRIC_PERMITTIVITY = 1 / (4 * PI)
 @pytest.mark.parametrize(
     "calc_doppler_width_sample_values_input_nu_line,calc_doppler_width_sample_values_input_temperature,calc_doppler_width_sample_values_input_atomic_mass, calc_doppler_width_sample_values_expected_result",
     [
-        (SPEED_OF_LIGHT, 0.5, BOLTZMANN_CONSTANT, 1.0),
-        # (0.0, 1.0 + 0.0j),
+        (
+            SPEED_OF_LIGHT,
+            0.5,
+            BOLTZMANN_CONSTANT,
+            1.0,
+        ),
+        (
+            np.array(2 * [SPEED_OF_LIGHT]),
+            np.array(2 * [0.5]),
+            np.array(2 * [BOLTZMANN_CONSTANT]),
+            np.array(2 * [1.0]),
+        ),
     ],
 )
 def test_calc_doppler_width_sample_values(
@@ -27,7 +37,7 @@ def test_calc_doppler_width_sample_values(
     calc_doppler_width_sample_values_input_atomic_mass,
     calc_doppler_width_sample_values_expected_result,
 ):
-    assert allclose(
+    assert np.allclose(
         calc_doppler_width(
             calc_doppler_width_sample_values_input_nu_line,
             calc_doppler_width_sample_values_input_temperature,

--- a/stardis/opacities/tests/test_broadening.py
+++ b/stardis/opacities/tests/test_broadening.py
@@ -1,0 +1,37 @@
+import pytest
+from numpy import allclose, pi as PI
+from astropy import constants as const
+
+from stardis.opacities.broadening import calc_doppler_width
+
+
+SPEED_OF_LIGHT = const.c.cgs.value
+BOLTZMANN_CONSTANT = const.k_B.cgs.value
+PLANCK_CONSTANT = const.h.cgs.value
+RYDBERG_ENERGY = (const.h.cgs * const.c.cgs * const.Ryd.cgs).value
+ELEMENTARY_CHARGE = const.e.esu.value
+BOHR_RADIUS = const.a0.cgs.value
+VACUUM_ELECTRIC_PERMITTIVITY = 1 / (4 * PI)
+
+
+@pytest.mark.parametrize(
+    "calc_doppler_width_sample_values_input_nu_line,calc_doppler_width_sample_values_input_temperature,calc_doppler_width_sample_values_input_atomic_mass, calc_doppler_width_sample_values_expected_result",
+    [
+        (SPEED_OF_LIGHT, 0.5, BOLTZMANN_CONSTANT, 1.0),
+        # (0.0, 1.0 + 0.0j),
+    ],
+)
+def test_calc_doppler_width_sample_values(
+    calc_doppler_width_sample_values_input_nu_line,
+    calc_doppler_width_sample_values_input_temperature,
+    calc_doppler_width_sample_values_input_atomic_mass,
+    calc_doppler_width_sample_values_expected_result,
+):
+    assert allclose(
+        calc_doppler_width(
+            calc_doppler_width_sample_values_input_nu_line,
+            calc_doppler_width_sample_values_input_temperature,
+            calc_doppler_width_sample_values_input_atomic_mass,
+        ),
+        calc_doppler_width_sample_values_expected_result,
+    )

--- a/stardis/opacities/tests/test_broadening.py
+++ b/stardis/opacities/tests/test_broadening.py
@@ -141,7 +141,7 @@ def test_calc_doppler_width_cuda_wrapped_sample_cuda_values(
             1.0,
         ),
         (
-            np.array(2 * [1.0]),
+            np.array(2 * [1]),
             np.array(2 * [RYDBERG_ENERGY]),
             np.array(2 * [0]),
             np.array(2 * [1.0]),


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

This pull request adds CUDA JIT to `calc_n_effective()`

It is ready for immediate merging after the merging of Pull Request #118 

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [X] Tested using Nvidia card

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request