### PR TITLE
Add next term van noort intensity solver

### DIFF
--- a/stardis/transport/base.py
+++ b/stardis/transport/base.py
@@ -115,7 +115,7 @@ def single_theta_trace(
             curr_tau = taus[i, j]
             next_tau = taus[i, j + 1]
 
-            w0, w1, w2 = calc_weights_w2(curr_tau)
+            w0, w1, w2 = calc_weights(curr_tau)
 
             if curr_tau == 0:
                 second_term = 0

--- a/stardis/transport/base.py
+++ b/stardis/transport/base.py
@@ -92,7 +92,6 @@ def calc_weights_w2(delta_tau):
         w0 = 1 - exp_delta_tau
         w1 = w0 - delta_tau * exp_delta_tau
         w2 = 2 * w1 - delta_tau * delta_tau * exp_delta_tau
-        print(w0, w1, w2)
     return w0, w1, w2
 
 
@@ -143,6 +142,7 @@ def single_theta_trace(
     for i in range(len(tracing_nus)):  # iterating over nus (columns)
         for j in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
             curr_tau = taus[i, j]
+            next_tau = taus[i, j + 1]
 
             w0, w1, w2 = calc_weights_w2(curr_tau)
 
@@ -153,11 +153,14 @@ def single_theta_trace(
             if j < no_of_depth_gaps - 1:
                 third_term = w2 * (
                     (
-                        (source[j + 2, i] - source[j + 1, i] / taus[i, j + 1])
-                        + ((source[j, i] - source[j + 1, i]) / taus[i, j])
+                        # (source[j + 2, i] - source[j + 1, i] / taus[i, j + 1])
+                        # + ((source[j, i] - source[j + 1, i]) / taus[i, j])
+                        (delta_source[j + 1, i] / next_tau)
+                        + (-delta_source[j, i] / curr_tau)
                     )
-                    / (taus[i, j] + taus[i, j + 1])
+                    / (curr_tau + next_tau)
                 )
+
             else:
                 third_term = 0
             I_nu_theta[j + 1, i] = (

--- a/stardis/transport/base.py
+++ b/stardis/transport/base.py
@@ -49,35 +49,6 @@ def calc_weights(delta_tau):
     -------
     w0 : float
     w1 : float
-    """
-
-    if delta_tau < 5e-4:
-        w0 = delta_tau * (1 - delta_tau / 2)
-        w1 = delta_tau**2 * (0.5 - delta_tau / 3)
-    elif delta_tau > 50:
-        w0 = 1.0
-        w1 = 1.0
-    else:
-        exp_delta_tau = np.exp(-delta_tau)
-        w0 = 1 - exp_delta_tau
-        w1 = w0 - delta_tau * exp_delta_tau
-    return w0, w1
-
-
-@numba.njit
-def calc_weights_w2(delta_tau):
-    """
-    Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
-
-    Parameters
-    ----------
-    delta_tau : float
-        Total optical depth.
-
-    Returns
-    -------
-    w0 : float
-    w1 : float
     w2: float
     """
 
@@ -153,8 +124,6 @@ def single_theta_trace(
             if j < no_of_depth_gaps - 1:
                 third_term = w2 * (
                     (
-                        # (source[j + 2, i] - source[j + 1, i] / taus[i, j + 1])
-                        # + ((source[j, i] - source[j + 1, i]) / taus[i, j])
                         (delta_source[j + 1, i] / next_tau)
                         + (-delta_source[j, i] / curr_tau)
                     )
@@ -204,9 +173,8 @@ def raytrace(stellar_model, alphas, tracing_nus, no_of_thetas=20):
     end_theta = (np.pi / 2) - (dtheta / 2)
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
     F_nu = np.zeros((len(stellar_model.geometry.r), len(tracing_nus)))
-    from tqdm.notebook import tqdm  # for testing purposes
 
-    for theta in tqdm(thetas):
+    for theta in thetas:
         weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
         F_nu += weight * single_theta_trace(
             stellar_model.geometry.dist_to_next_depth_point,


### PR DESCRIPTION
### :pencil: Description

**Type:** | :rocket: `feature` | :vertical_traffic_light: `testing` | 

This PR adds the next term of the van noort 2001 equation we solve to do radiative transfer. It seems like it changes our answer at the 0.1% level, which is small enough that it's not a particularly significant change, but the radiative transfer equation is also such a small part of the runtime of the code that I think it's worth doing by default. If people think it's necessary, we can make this an option that can be turned on or off, but I think we should just adopt it into the code always because the performance increase is negligible. I've run the benchmarks a couple times and have not seen a statistically significant change in runtime. 

As a note, if we can get [PR 85](https://github.com/tardis-sn/stardis/pull/85#issue-1797279075) merged first, it'd be nice to see the timing difference in the raytrace function itself. 

### :pushpin: Resources

From https://iopscience.iop.org/article/10.1086/338949/pdf equation 14. Adding the w2 d2S/dt2 term. 


### :vertical_traffic_light: Testing

Normalized residuals about H-alpha line can be seen here. There's a systematic offset at the 0.1% level. 

I'm adding the benchmarks label so we can see if this is a significant slowdown. 

![normalized_residuals](https://github.com/tardis-sn/stardis/assets/54691495/eb69214e-2e15-4100-8b5b-ee760318b3de)


- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
