### PR TITLE
add units to stardis outputs

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -116,18 +116,18 @@ class STARDISOutput:
     doppler_widths : numpy.ndarray
         Array of shape (no_of_lines, no_of_depth_points). Doppler width of each
         line at each depth point.
-    F_nu : numpy.ndarray
+    F_nu : astropy.units.Quantity
         Array of shape (no_of_depth points, no_of_frequencies). Output flux with
-        respect to frequency at each depth point for each frequency.
-    F_lambda : numpy.ndarray
+        respect to frequency at each depth point for each frequency. Units of erg/s/cm^2/Hz.
+    F_lambda : astropy.units.Quantity
         Array of shape (no_of_depth_points, no_of_frequencies). Output flux with
-        respect to wavelength at each depth point for each wavelength.
-    spectrum_nu : numpy.ndarray
+        respect to wavelength at each depth point for each wavelength. Units of erg/s/cm^2/Angstrom.
+    spectrum_nu : astropy.units.Quantity
         Output flux with respect to frequency at the outermost depth point for each
-        frequency.
-    spectrum_lambda : numpy.ndarray
+        frequency. Units of erg/s/cm^2/Hz.
+    spectrum_lambda : astropy.units.Quantity
         Output flux with respect to wavelength at the outermost depth point for each
-        wavelength.
+        wavelength. Units of erg/s/cm^2/Angstrom.
     nus : astropy.units.Quantity
         Numpy array of frequencies used for spectrum with units of Hz.
     lambdas : astropy.units.Quantity
@@ -143,13 +143,11 @@ class STARDISOutput:
         self.gammas = gammas
         self.doppler_widths = doppler_widths
 
-        length = len(F_nu)
-        lambdas = nus.to(u.AA, u.spectral())
-        F_lambda = F_nu * nus / lambdas
-        # TODO: Units
-        self.F_nu = F_nu
-        self.F_lambda = F_lambda.value
-        self.spectrum_nu = F_nu[-1]
-        self.spectrum_lambda = F_lambda[-1]
         self.nus = nus
-        self.lambdas = lambdas
+        self.lambdas = nus.to(u.AA, u.spectral())
+
+        self.F_nu = F_nu * u.erg / u.s / u.cm**2 / u.Hz
+        self.F_lambda = self.F_nu * nus / self.lambdas
+
+        self.spectrum_nu = self.F_nu[-1]
+        self.spectrum_lambda = self.F_lambda[-1]

--- a/stardis/base.py
+++ b/stardis/base.py
@@ -147,7 +147,9 @@ class STARDISOutput:
         self.lambdas = nus.to(u.AA, u.spectral())
 
         self.F_nu = F_nu * u.erg / u.s / u.cm**2 / u.Hz
-        self.F_lambda = self.F_nu * nus / self.lambdas
+        self.F_lambda = (self.F_nu * nus / self.lambdas).to(
+            u.erg / u.s / u.cm**2 / u.AA
+        )
 
         self.spectrum_nu = self.F_nu[-1]
         self.spectrum_lambda = self.F_lambda[-1]


### PR DESCRIPTION
### :pencil: Description

Adds units to Stardis output. They're just simply added on the end as appropriate, which feels a little hacky, but they generally cannot be carried along deeper for njitting purposes. 

If there is a better suggestion for how to do this I'd love to hear. 


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
