### PR TITLE
Fix breaking benchmark pipeline

### DIFF
--- a/benchmarks/run_stardis.py
+++ b/benchmarks/run_stardis.py
@@ -26,13 +26,13 @@ class BenchmarkStardis:
     def setup(self):
         base_dir = os.path.abspath(os.path.dirname(__file__))
         schema = os.path.join(base_dir, "config_schema.yml")
-        config = os.path.join(base_dir, "benchmark_config.yml")
+        config_file = os.path.join(base_dir, "benchmark_config.yml")
         tracing_lambdas = np.arange(6540, 6590, 0.01) * u.Angstrom
         os.chdir(base_dir)
 
         tracing_nus = tracing_lambdas.to(u.Hz, u.spectral())
 
-        config_dict = validate_yaml(config, schemapath=schema)
+        config_dict = validate_yaml(config_file, schemapath=schema)
         config = Configuration(config_dict)
 
         adata = AtomData.from_hdf(config.atom_data)
@@ -73,9 +73,10 @@ class BenchmarkStardis:
         self.tracing_nus = tracing_nus
         self.tracing_lambdas = tracing_lambdas
         self.config = config
+        self.config_file = config_file
 
     def time_run_stardis(self):
-        run_stardis(self.config, self.tracing_lambdas)
+        run_stardis(self.config_file, self.tracing_lambdas)
 
     def time_raytrace(self):
         raytrace(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

An incorrect config parameter was passed to one of the benchmarks which was causing the [benchmark workflow to fail.](https://github.com/tardis-sn/stardis/actions/runs/5904330002/job/16016165642)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
