### PR TITLE
Revert changes to `voigt_profile()` formula

### DIFF
--- a/stardis/opacities/tests/test_voigt.py
+++ b/stardis/opacities/tests/test_voigt.py
@@ -151,13 +151,13 @@ def test_voigt_profile_division_by_zero(
 @pytest.mark.parametrize(
     "voigt_profile_sample_values_input_delta_nu, voigt_profile_sample_values_input_doppler_width, voigt_profile_sample_values_input_gamma, voigt_profile_sample_values_expected_result",
     [
-        (0, 1, 0, 1 / sqrt(np.pi) / sqrt(2)),
-        (0, 2, 0, 1 / (sqrt(np.pi) * 2 * sqrt(2))),
+        (0, 1, 0, 1 / sqrt(np.pi)),
+        (0, 2, 0, 1 / (sqrt(np.pi) * 2)),
         (
             np.array([0, 0]),
             np.array([1, 2]),
             np.array([0, 0]),
-            np.array([1 / sqrt(2) / sqrt(np.pi), 1 / (sqrt(2) * sqrt(np.pi) * 2)]),
+            np.array([1 / sqrt(np.pi), 1 / (sqrt(np.pi) * 2)]),
         ),
     ],
 )
@@ -188,7 +188,7 @@ def test_voigt_profile_sample_values_sample_values(
             np.array([0, 0]),
             np.array([1, 2]),
             np.array([0, 0]),
-            np.array([1 / sqrt(2) / sqrt(np.pi), 1 / (sqrt(np.pi) * 2 * sqrt(2))]),
+            np.array([1 / sqrt(np.pi), 1 / (sqrt(np.pi) * 2)]),
         ),
     ],
 )
@@ -229,7 +229,7 @@ def test_voigt_profile_cuda_unwrapped_sample_values(
             np.array([0, 0]),
             np.array([1, 2]),
             np.array([0, 0]),
-            np.array([1 / sqrt(2) / sqrt(np.pi), 1 / (sqrt(2) * sqrt(np.pi) * 2)]),
+            np.array([1 / sqrt(np.pi), 1 / (sqrt(np.pi) * 2)]),
         ),
     ],
 )
@@ -261,7 +261,7 @@ def test_voigt_profile_cuda_wrapped_sample_numpy_values(
             np.array([0, 0]),
             np.array([1, 2]),
             np.array([0, 0]),
-            np.array([1 / sqrt(np.pi) / sqrt(2), 1 / (sqrt(np.pi) * 2 * sqrt(2))]),
+            np.array([1 / sqrt(np.pi), 1 / (sqrt(np.pi) * 2)]),
         ),
     ],
 )

--- a/stardis/opacities/voigt.py
+++ b/stardis/opacities/voigt.py
@@ -132,8 +132,8 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     """
     delta_nu, doppler_width, gamma = float(delta_nu), float(doppler_width), float(gamma)
 
-    z = complex(delta_nu, gamma) / (SQRT_2 * doppler_width)
-    phi = _faddeeva(z).real / (SQRT_2 * SQRT_PI * doppler_width)
+    z = complex(delta_nu, gamma / (4 * PI)) / doppler_width
+    phi = _faddeeva(z).real / (SQRT_PI * doppler_width)
     return phi
 
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

This reverts the change to the `voigt_profile()` formula as discussed in the stardis meeting today

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
