### PR TITLE
add w2 in the small and large delta tau case

### DIFF
--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -24,9 +24,11 @@ def calc_weights(delta_tau):
     if delta_tau < 5e-4:
         w0 = delta_tau * (1 - delta_tau / 2)
         w1 = delta_tau**2 * (0.5 - delta_tau / 3)
+        w2 = delta_tau**3 * (1 / 3 - delta_tau / 4)
     elif delta_tau > 50:
         w0 = 1.0
         w1 = 1.0
+        w2 = 2.0
     else:
         exp_delta_tau = np.exp(-delta_tau)
         w0 = 1 - exp_delta_tau


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

The W2 weight was not calculated in the large and small tau case, so the code would crash in those cases. This adds the appropriate weight calculation for W2. This branch was created on top of the radiation field branch so that should probably be merged first for ease of conflicts.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
