### PR TITLE
Fix benchmarking action not pushing results to the results repo

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           source-directory: ".asv"
           destination-github-username: "tardis-sn"
+          destination-repository-name: "stardis-benchmarks"
           user.email: tardis.sn.bot@gmail.com
           target-branch: main
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Benchmarking workflow is not pushing results to the [intended repository ](https://github.com/tardis-sn/stardis-benchmarks).
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
