### PR TITLE
small benchmarking cleanup

### DIFF
--- a/benchmarks/benchmark_config.yml
+++ b/benchmarks/benchmark_config.yml
@@ -15,6 +15,6 @@ opacity:
     line:
         disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
-        min: 6500 AA
-        max: 6600 AA
+        min: 6550 AA
+        max: 6575 AA
 no_of_thetas: 20

--- a/benchmarks/run_stardis.py
+++ b/benchmarks/run_stardis.py
@@ -29,7 +29,7 @@ class BenchmarkStardis:
         base_dir = os.path.abspath(os.path.dirname(__file__))
         schema = os.path.join(base_dir, "config_schema.yml")
         config_file = os.path.join(base_dir, "benchmark_config.yml")
-        tracing_lambdas = np.arange(6540, 6590, 0.01) * u.Angstrom
+        tracing_lambdas = np.arange(6550, 6575, 0.05) * u.Angstrom
         os.chdir(base_dir)
 
         tracing_nus = tracing_lambdas.to(u.Hz, u.spectral())
@@ -40,7 +40,7 @@ class BenchmarkStardis:
         adata = AtomData.from_hdf(config.atom_data)
 
         if config.model.type == "marcs":
-            raw_marcs_model = read_marcs_model(config.model.fname, gzipped=False)
+            raw_marcs_model = read_marcs_model(config.model.fname)
             stellar_model = raw_marcs_model.to_stellar_model(
                 adata, final_atomic_number=config.model.final_atomic_number
             )
@@ -73,10 +73,11 @@ class BenchmarkStardis:
             opacity_config=config.opacity,
         )
 
-        self.stellar_plasma = stellar_plasma
-        self.stellar_model = stellar_model
-        self.stellar_radiation_field = stellar_radiation_field
         self.tracing_lambdas = tracing_lambdas
+
+        self.stellar_model = stellar_model
+        self.stellar_plasma = stellar_plasma
+        self.stellar_radiation_field = stellar_radiation_field
         self.config = config
         self.config_file = config_file
 

--- a/benchmarks/run_stardis.py
+++ b/benchmarks/run_stardis.py
@@ -40,7 +40,9 @@ class BenchmarkStardis:
         adata = AtomData.from_hdf(config.atom_data)
 
         if config.model.type == "marcs":
-            raw_marcs_model = read_marcs_model(config.model.fname)
+            raw_marcs_model = read_marcs_model(
+                config.model.fname, gzipped=config.model.gzipped
+            )
             stellar_model = raw_marcs_model.to_stellar_model(
                 adata, final_atomic_number=config.model.final_atomic_number
             )


### PR DESCRIPTION
Small changes, mostly making the wavelength range smaller for benchmarking and matching the lines considered wavelength range to the wavelengths of the simulation. 

The should mainly speed up the benchmarks for a small quality of life improvement. 