### PR TITLE
Remove tests that use cuda because GitHub doesn't run them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,9 @@ jobs:
           label: linux-64
           prefix: /usr/share/miniconda3/envs/stardis
 
-        - os: ubuntu-latest
-          label: linux-64-cuda
-          prefix: /usr/share/miniconda3/envs/stardis
+        # - os: ubuntu-latest
+        #   label: linux-64-cuda
+        #   prefix: /usr/share/miniconda3/envs/stardis
 
         - os: macos-latest
           label: osx-64


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Remove tests that use cuda because GitHub Actions does not provide GPUs.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request