### PR TITLE
Make `atom_data` "python-touchable` so that arbitrary data can be used

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -18,7 +18,7 @@ base_dir = os.path.abspath(os.path.dirname(__file__))
 schema = os.path.join(base_dir, "config_schema.yml")
 
 
-def run_stardis(config_fname, tracing_lambdas_or_nus):
+def run_stardis(config_fname, tracing_lambdas_or_nus, atom_data=None):
     """
     Runs a STARDIS simulation.
 
@@ -69,6 +69,8 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
             )
             + 1,
         )
+        if atom_data == None
+        else atom_data
     )
     # plasma
     stellar_plasma = create_stellar_plasma(stellar_model, adata)


### PR DESCRIPTION
### :pencil: Make `atom_data` "python-touchable` so that arbitrary data can be used

**Type:** :rocket: `feature` 

Add optional keyword argument that defaults to `None` so that arbitrary atom data can be used. If none is provided, use preexisting logic.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label