### PR TITLE
Shortlist calculation

### DIFF
--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -102,9 +102,15 @@ properties:
                     broadening_range:
                         type: [quantity, "null"]
                         default: null
-                    use_vald_linelist:
-                        type: boolean
-                        default: false
+                    vald_linelist:
+                        properties:
+                            use_linelist:
+                                type: boolean
+                                default: false
+                            type: boolean
+                            shortlist:
+                                type: boolean
+                                default: false
         #required:
         #- line
     no_of_thetas:

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -103,6 +103,8 @@ properties:
                         type: [quantity, "null"]
                         default: null
                     vald_linelist:
+                        type: object
+                        default: {}
                         properties:
                             use_linelist:
                                 type: boolean

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -396,8 +396,8 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (
-            linelist["rad"]
+        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
+            4 * np.pi
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -155,7 +155,6 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         atomic_data,
         ion_number_density,
         t_electrons,
-        g,
         ionization_data,
         partition_function,
     ):
@@ -163,6 +162,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         # get f_lu : loggf -> use g = 2j+1
         # emission_correction = (1-e^(-h*nu / kT))
         # alphas = ALPHA_COEFFICIENT * n_lower * f_lu * emission_correction
+
+        ###TODO: handle other broadening parameters
 
         points = len(t_electrons)
 
@@ -298,10 +299,10 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         atomic_data,
         ion_number_density,
         t_electrons,
-        g,
         ionization_data,
         partition_function,
     ):
+        ###TODO: handle other broadening parameters
         points = len(t_electrons)
 
         linelist = atomic_data.linelist.rename(columns={"ion_charge": "ion_number"})[
@@ -348,8 +349,6 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
             exponent_by_point * linelist_with_densities[np.arange(points)]
         ).values.T  # arange mask of the dataframe returns the set of densities of the appropriate ion for the line at each point
 
-        linelist["gf"] = 10**linelist.log_gf
-
         line_nus = (linelist.wavelength.values * u.AA).to(
             u.Hz, equivalencies=u.spectral()
         )
@@ -369,7 +368,7 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
             (
                 ALPHA_COEFFICIENT
                 * prefactor
-                * linelist.gf.values
+                * 10**linelist.log_gf.values
                 * emission_correction.T
             ).T
         )

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -166,8 +166,6 @@ class AlphaLineVald(ProcessingPlasmaProperty):
 
         points = len(t_electrons)
 
-        # Need degeneracy of ground state of the ion to calculate n_lower
-        # So set up the initial dataframe with all of the necessary information, and then merge it with the matching g_0
         linelist = atomic_data.linelist.rename(columns={"ion_charge": "ion_number"})[
             [
                 "atomic_number",
@@ -182,11 +180,7 @@ class AlphaLineVald(ProcessingPlasmaProperty):
                 "stark",
                 "waals",
             ]
-        ].merge(
-            g.loc[:, :, 0].rename("g_0"),
-            how="left",
-            on=["atomic_number", "ion_number"],
-        )
+        ]
 
         # Truncate to final atomic number
         linelist = linelist[
@@ -203,7 +197,7 @@ class AlphaLineVald(ProcessingPlasmaProperty):
             ).to(1)
         )
 
-        # grab densities for n_lower - need to use linelist as the index and normalize by dviding by the partition function
+        # grab densities for n_lower - need to use linelist as the index and normalize by dividing by the partition function
         linelist_with_densities = linelist.merge(
             ion_number_density / partition_function,
             how="left",
@@ -310,8 +304,6 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
     ):
         points = len(t_electrons)
 
-        # Need degeneracy of ground state of the ion
-        # So set up the initial dataframe with all of the necessary information, and then merge it with the matching g_0
         linelist = atomic_data.linelist.rename(columns={"ion_charge": "ion_number"})[
             [
                 "atomic_number",
@@ -323,11 +315,7 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
                 "stark",
                 "waals",
             ]
-        ].merge(
-            g.loc[:, :, 0].rename("g_0"),
-            how="left",
-            on=["atomic_number", "ion_number"],
-        )
+        ]
 
         # Truncate to final atomic number
         linelist = linelist[

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -138,6 +138,9 @@ class AlphaLineVald(ProcessingPlasmaProperty):
             for each line from Vald at each depth point. Refer to Rybicki and Lightman
             equation 1.80. Voigt profiles are calculated later, and B_12 is substituted
             appropriately out for f_lu. This assumes LTE for lower level population.
+    lines_from_linelist: DataFrame
+            A pandas dataframe containing the lines and information about the lines in
+            the same form and shape as alpha_line_from_linelist.
     """
 
     outputs = ("alpha_line_from_linelist", "lines_from_linelist")
@@ -275,10 +278,6 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         return alphas[valid_indices], linelist[valid_indices]
 
 
-# Properties that haven't been used in creating stellar plasma yet,
-# might be useful in future ----------------------------------------------------
-
-
 class AlphaLineShortlistVald(ProcessingPlasmaProperty):
     """
     Attributes
@@ -287,8 +286,10 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
             A pandas DataFrame with dtype float. This represents the alpha calculation
             for each line from Vald at each depth point. This is adapted from the AlphaLineVald calculation
             because shortlists do not contain js or an upper energy level. This works because the degeneracies
-            cancel out in the final calaculation anyway.
-
+            cancel between the n_lower recalculation and in calculating f_lu from g*f given by the linelist.
+    lines_from_linelist: DataFrame
+            A pandas dataframe containing the lines and information about the lines in
+            the same form and shape as alpha_line_from_linelist.
     """
 
     outputs = ("alpha_line_from_linelist", "lines_from_linelist")
@@ -418,6 +419,10 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         valid_indices = linelist.level_energy_upper < linelist.ionization_energy
 
         return alphas[valid_indices], linelist[valid_indices]
+
+
+# Properties that haven't been used in creating stellar plasma yet,
+# might be useful in future ----------------------------------------------------
 
 
 class InputNumberDensity(DataFrameInput):

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -386,8 +386,7 @@ def calc_alpha_line_at_nu(
     quadratic_stark = "quadratic_stark" in broadening_methods
     van_der_waals = "van_der_waals" in broadening_methods
     radiation = "radiation" in broadening_methods
-
-    use_vald = line_opacity_config.use_vald_linelist
+    use_vald = line_opacity_config.vald_linelist.use_linelist
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:


### PR DESCRIPTION
This calculates opacities with the short form of a vald linelist. Allows us to directly compare to korg (since as far as we can tell they can't use the long-form linelist). Also modifies the config schema to accept a shortlist specification so that the new calculation can be used. 

At some point soon it'd be nice to get proper regression tests going, since that's the easiest way to test the plasma. This seems to me like the best way to test the different plasmas and calculated opacities. 