### PR TITLE
attempt benchmark fix

### DIFF
--- a/benchmarks/run_stardis.py
+++ b/benchmarks/run_stardis.py
@@ -62,7 +62,7 @@ class BenchmarkStardis:
             )
         )
 
-        stellar_plasma = create_stellar_plasma(stellar_model, adata)
+        stellar_plasma = create_stellar_plasma(stellar_model, adata, config)
 
         stellar_radiation_field = RadiationField(
             tracing_nus, blackbody_flux_at_nu, stellar_model


### PR DESCRIPTION
I tracked down a bug in the benchmarks - why they haven't been able to run for awhile.

It's a small change, but the config is necessary now to create the plasma and that wasn't passed along to the benchmark model creation. Hopefully the benchmarks will run again now with this. 