### PR TITLE
fix linear stark parameter to match paper source

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -206,7 +206,7 @@ def _calc_gamma_linear_stark(n_eff_upper, n_eff_lower, electron_density):
     a1 = 0.642 if (n_eff_upper - n_eff_lower < 1.5) else 1.0
 
     gamma_linear_stark = (
-        0.51
+        0.60
         * a1
         * (n_eff_upper**2 - n_eff_lower**2)
         * (electron_density ** (2.0 / 3.0))


### PR DESCRIPTION
Seems like we might have a slightly incorrect linear broadening treatment due to a typo. This PR should fix that. 