### PR TITLE
Improve broadening range treatment

### DIFF
--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -15,6 +15,11 @@ from stardis.radiation_field import RadiationField
 from stardis.radiation_field.source_functions.blackbody import blackbody_flux_at_nu
 from stardis import SCHEMA_PATH, STARDISOutput
 
+EXAMPLE_CONF_PATH = Path(__file__).parent / "tests" / "stardis_test_config.yml"
+EXAMPLE_CONF_PATH_BROADENING = (
+    Path(__file__).parent / "tests" / "stardis_test_config_broadening.yml"
+)
+
 
 @pytest.fixture(scope="session")
 def example_tracing_nus():
@@ -30,13 +35,14 @@ def example_kurucz_atomic_data():
 
 
 @pytest.fixture(scope="session")
-def example_conf_path():
-    return Path(__file__).parent / "tests" / "stardis_test_config.yml"
+def example_config():
+    config_dict = validate_yaml(EXAMPLE_CONF_PATH, schemapath=SCHEMA_PATH)
+    return Configuration(config_dict)
 
 
 @pytest.fixture(scope="session")
-def example_config(example_conf_path):
-    config_dict = validate_yaml(example_conf_path, schemapath=SCHEMA_PATH)
+def example_config_broadening():
+    config_dict = validate_yaml(EXAMPLE_CONF_PATH_BROADENING, schemapath=SCHEMA_PATH)
     return Configuration(config_dict)
 
 

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -407,27 +407,23 @@ def calc_alpha_line_at_nu(
         lines.columns.to_list()
     )  ###TODO: Fix this map_items_to_indices. Probably remove the function.
 
-    lines_sorted = lines.sort_values("nu").reset_index(drop=True)
-    lines_sorted_in_range = lines_sorted[
+    lines_sorted = lines.sort_values("nu")
+    lines_array = lines_sorted[
         lines_sorted.nu.between(line_nu_min, line_nu_max)
-    ]
-    lines_array = lines_sorted_in_range.to_numpy()
+    ].to_numpy()
 
     h_densities = stellar_plasma.ion_number_density.loc[1, 0].to_numpy()
 
     if use_vald:
-        alphas_and_nu = stellar_plasma.alpha_line_from_linelist.sort_values(
-            "nu"
-        ).reset_index(drop=True)
+        alphas_and_nu = stellar_plasma.alpha_line_from_linelist.sort_values("nu")
     else:
-        alphas_and_nu = stellar_plasma.alpha_line.sort_values("nu").reset_index(
-            drop=True
-        )
-    alphas_and_nu_in_range = alphas_and_nu[
-        alphas_and_nu.nu.between(line_nu_min, line_nu_max)
-    ]
-    alphas = alphas_and_nu_in_range.drop(labels="nu", axis=1)
-    alphas_array = alphas.to_numpy()
+        alphas_and_nu = stellar_plasma.alpha_line.sort_values("nu")
+
+    alphas_array = (
+        alphas_and_nu[alphas_and_nu.nu.between(line_nu_min, line_nu_max)]
+        .drop(labels="nu", axis=1)
+        .to_numpy()
+    )
 
     line_nus, gammas, doppler_widths = calculate_broadening(
         lines_array,

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -377,9 +377,7 @@ def calc_alpha_line_at_nu(
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:
-        lines = (
-            stellar_plasma.lines.reset_index()
-        )  # bring lines in ascending order of nu TODO: this doesn't actually do this - they are ascending wavelengths not frequencies - cleanup in future
+        lines = stellar_plasma.lines
 
         # add ionization energy to lines
         ionization_data = stellar_plasma.ionization_data.reset_index()
@@ -459,10 +457,16 @@ def calc_alpha_line_at_nu(
             line_range_value = (tracing_nus - nus_plus_broadening_range).value
         elif line_range.unit.physical_type == "frequency":
             line_range_value = line_range.to(u.Hz).value
+        else:
+            raise ValueError(
+                "Broadening range must be in units of length or frequency."
+            )
 
     for i, nu in enumerate(tracing_nus):
         delta_nus = nu.value - line_nus
-        broadening_mask = np.abs(delta_nus) < line_range_value[i]
+
+        if line_range is not None:
+            broadening_mask = np.abs(delta_nus) < line_range_value[i]
 
         for j in range(stellar_model.no_of_depth_points):
             gammas_at_depth_point = gammas[:, j]

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -377,7 +377,7 @@ def calc_alpha_line_at_nu(
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:
-        lines = stellar_plasma.lines.reset_index(drop=True)
+        lines = stellar_plasma.lines.reset_index()
 
         # add ionization energy to lines
         ionization_data = stellar_plasma.ionization_data.reset_index()

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -377,7 +377,7 @@ def calc_alpha_line_at_nu(
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:
-        lines = stellar_plasma.lines
+        lines = stellar_plasma.lines.reset_index(drop=True)
 
         # add ionization energy to lines
         ionization_data = stellar_plasma.ionization_data.reset_index()

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -415,10 +415,6 @@ def calc_alpha_line_at_nu(
     ]
     lines_array = lines_sorted_in_range.to_numpy()
 
-    atomic_masses = stellar_plasma.atomic_mass.values
-    temperatures = stellar_model.temperatures.value
-    electron_densities = stellar_plasma.electron_densities.values
-
     h_densities = stellar_plasma.ion_number_density.loc[1, 0].to_numpy()
 
     if use_vald:
@@ -439,9 +435,9 @@ def calc_alpha_line_at_nu(
         lines_array,
         line_cols,
         stellar_model.no_of_depth_points,
-        atomic_masses,
-        electron_densities,
-        temperatures,
+        stellar_plasma.atomic_mass.values,
+        stellar_plasma.electron_densities.values,
+        stellar_model.temperatures.value,
         h_densities,
         linear_stark=linear_stark,
         quadratic_stark=quadratic_stark,
@@ -458,7 +454,7 @@ def calc_alpha_line_at_nu(
             nus_plus_broadening_range = lambdas_plus_broadening_range.to(
                 u.Hz, equivalencies=u.spectral()
             )
-            line_range_value = (nus_plus_broadening_range - tracing_nus).value
+            line_range_value = (tracing_nus - nus_plus_broadening_range).value
         elif line_range.unit.physical_type == "frequency":
             line_range_value = line_range.to(u.Hz).value
 
@@ -478,11 +474,10 @@ def calc_alpha_line_at_nu(
                     alphas_at_depth_point,
                 )
 
-            else:
+            else:  # Probably this else should actually just check if delta_nus is less than line_range_value.
                 # line_range_value = line_range.to(u.Hz, equivalencies=u.spectral()).value
-                line_start = line_nus.searchsorted(nu - line_range_value[i]) + 1
-                line_end = line_nus.searchsorted(nu + line_range_value[i]) + 1
-                print(line_start, line_end)
+                line_start = line_nus.searchsorted(nu.value - line_range_value[i]) + 1
+                line_end = line_nus.searchsorted(nu.value + line_range_value[i]) + 1
                 delta_nus_considered = delta_nus[line_start:line_end]
                 gammas_considered = gammas_at_depth_point[line_start:line_end]
                 doppler_widths_considered = doppler_widths_at_depth_point[

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -377,10 +377,10 @@ def calc_alpha_line_at_nu(
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:
-        lines = stellar_plasma.lines.reset_index()
+        lines = stellar_plasma.lines
 
         # add ionization energy to lines
-        ionization_data = stellar_plasma.ionization_data.reset_index()
+        ionization_data = stellar_plasma.ionization_data
         ionization_data["ion_number"] -= 1
         lines = pd.merge(
             lines, ionization_data, how="left", on=["atomic_number", "ion_number"]

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -447,7 +447,9 @@ def calc_alpha_line_at_nu(
 
     alpha_line_at_nu = np.zeros((stellar_model.no_of_depth_points, len(tracing_nus)))
 
-    if line_range is not None:
+    if (
+        line_range is not None
+    ):  # This if statement block appropriately handles if the broadening range is in frequency or wavelength units.
         if line_range.unit.physical_type == "length":
             lambdas = tracing_nus.to(u.AA, equivalencies=u.spectral())
             lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -460,6 +460,7 @@ def calc_alpha_line_at_nu(
 
     for i, nu in enumerate(tracing_nus):
         delta_nus = nu.value - line_nus
+        broadening_mask = np.abs(delta_nus) < line_range_value[i]
 
         for j in range(stellar_model.no_of_depth_points):
             gammas_at_depth_point = gammas[:, j]
@@ -474,16 +475,13 @@ def calc_alpha_line_at_nu(
                     alphas_at_depth_point,
                 )
 
-            else:  # Probably this else should actually just check if delta_nus is less than line_range_value.
-                # line_range_value = line_range.to(u.Hz, equivalencies=u.spectral()).value
-                line_start = line_nus.searchsorted(nu.value - line_range_value[i]) + 1
-                line_end = line_nus.searchsorted(nu.value + line_range_value[i]) + 1
-                delta_nus_considered = delta_nus[line_start:line_end]
-                gammas_considered = gammas_at_depth_point[line_start:line_end]
+            else:
+                delta_nus_considered = delta_nus[broadening_mask]
+                gammas_considered = gammas_at_depth_point[broadening_mask]
                 doppler_widths_considered = doppler_widths_at_depth_point[
-                    line_start:line_end
+                    broadening_mask
                 ]
-                alphas_considered = alphas_at_depth_point[line_start:line_end]
+                alphas_considered = alphas_at_depth_point[broadening_mask]
                 alpha_line_at_nu[j, i] = calc_alan_entries(
                     delta_nus_considered,
                     doppler_widths_considered,

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -377,10 +377,10 @@ def calc_alpha_line_at_nu(
     if use_vald:
         lines = stellar_plasma.lines_from_linelist
     else:
-        lines = stellar_plasma.lines
+        lines = stellar_plasma.lines.reset_index()
 
         # add ionization energy to lines
-        ionization_data = stellar_plasma.ionization_data
+        ionization_data = stellar_plasma.ionization_data.reset_index()
         ionization_data["ion_number"] -= 1
         lines = pd.merge(
             lines, ionization_data, how="left", on=["atomic_number", "ion_number"]

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacties_solvers.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacties_solvers.py
@@ -1,7 +1,7 @@
 from stardis.radiation_field.opacities.opacities_solvers import calc_alpha_line_at_nu
 
 
-def test_calc_alpha_line_at_nu(
+def test_calc_alpha_line_at_nu_with_broadening(
     example_stellar_plasma,
     example_stellar_model,
     example_tracing_nus,

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacties_solvers.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacties_solvers.py
@@ -1,0 +1,17 @@
+from stardis.radiation_field.opacities.opacities_solvers import calc_alpha_line_at_nu
+
+
+def test_calc_alpha_line_at_nu(
+    example_stellar_plasma,
+    example_stellar_model,
+    example_tracing_nus,
+    example_config_broadening,
+):
+    alpha_line_at_nu, gammas, doppler_widths = calc_alpha_line_at_nu(
+        example_stellar_plasma,
+        example_stellar_model,
+        example_tracing_nus,
+        example_config_broadening.opacity.line,
+    )
+    assert len(gammas) == len(doppler_widths)
+    assert len(alpha_line_at_nu) == example_stellar_model.no_of_depth_points

--- a/stardis/tests/stardis_test_config_broadening.yml
+++ b/stardis/tests/stardis_test_config_broadening.yml
@@ -1,0 +1,22 @@
+stardis_config_version: 1.0
+atom_data: kurucz_cd23_chianti_H_He.h5
+model:
+    type: marcs
+    fname: docs/quickstart/sun.mod
+    final_atomic_number: 5
+opacity:
+    bf:
+        H_I: {}
+    ff:
+        H_I: {}
+    disable_electron_scattering: False
+    line:
+        disable: False
+        broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
+        min: 6560 AA
+        max: 6570 AA
+        vald_linelist: 
+            use_linelist: False
+            shortlist: False
+        broadening_range: 1 AA         
+no_of_thetas: 1


### PR DESCRIPTION
Broadening range restrictions (the space around a line where the line was considered as adding to opacity) were previously non-functional. This meant that all of our simulations, especially the broader ones, scaled highly non-linearly with the wavelength range because all lines were considered as adding to all opacities at all wavelengths or frequencies.

This pr makes that broadening range restriction functional and should create a large speedup for broad wavelength simulations.

The pr also includes a bit of cleaning to make the function generally neater and remove a couple of non-functional calculations (a lot of resetting indices of dataframes that didn't make any functional change). 