### PR TITLE
remove alpha_electron for loop

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -170,9 +170,9 @@ def calc_alpha_electron(
         const.sigma_T.cgs.value * stellar_plasma.electron_densities.values
     )
 
-    alpha_electron = np.zeros((stellar_model.no_of_depth_points, len(tracing_nus)))
-    for j in range(stellar_model.no_of_depth_points):
-        alpha_electron[j] = alpha_electron_by_depth_point[j]
+    alpha_electron = np.repeat(
+        alpha_electron_by_depth_point[:, np.newaxis], len(tracing_nus), axis=1
+    )
 
     return alpha_electron
 


### PR DESCRIPTION
Small pr to rectify a small inefficiency I came across in the code. 

This just changes a bulky for loop to use a more efficient numpy implementation. 