### PR TITLE
fix bug that overwrote first entry in opacities_dict

### DIFF
--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -6,7 +6,6 @@ class RadiationField:
     """
     Class containing information about the radiation field.
     ###TODO Radiation field temperature should be a separate attribute, for the case of differing gas and radiation.
-    ###TODO Implement a source function class. Doesn't need to be done until we have another source function than just blackbody.
 
     Parameters
     ----------
@@ -30,5 +29,5 @@ class RadiationField:
     def __init__(self, frequencies, source_function, stellar_model):
         self.frequencies = frequencies
         self.source_function = source_function
-        self.opacities = Opacities()
-        self.F_nu = np.zeros((len(stellar_model.geometry.r), len(frequencies)))
+        self.opacities = Opacities(frequencies, stellar_model)
+        self.F_nu = np.zeros((stellar_model.no_of_depth_points, len(frequencies)))

--- a/stardis/radiation_field/opacities/base.py
+++ b/stardis/radiation_field/opacities/base.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 class Opacities:
     """
     Holds opacity information.
@@ -11,15 +14,15 @@ class Opacities:
         Added as an attribute when calc_total_alphas() is called.
     """
 
-    def __init__(self):
+    def __init__(self, frequencies, stellar_model):
         self.opacities_dict = {}
+        self.total_alphas = np.zeros(
+            (stellar_model.no_of_depth_points, len(frequencies))
+        )
 
     ###TODO: Better implementation for this
     def calc_total_alphas(self):
-        for i, item in enumerate(self.opacities_dict.items()):
+        for item in self.opacities_dict.items():
             if "gammas" not in item[0] and "doppler" not in item[0]:
-                if i == 0:
-                    self.total_alphas = item[1]
-                else:
-                    self.total_alphas += item[1]
+                self.total_alphas += item[1]
         return self.total_alphas


### PR DESCRIPTION
I introduced a bug when originally creating the Opacities object in the calc_total_opacities() method. This is a more sane way of calculating total opacities with an initialization that doesn't just point the total opacities to the first entry of the dictionary. 