### PR TITLE
give benchmarks.yml a target directory

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -112,7 +112,8 @@ jobs:
           destination-repository-name: "stardis-benchmarks"
           user.email: tardis.sn.bot@gmail.com
           target-branch: main
-
+          target-directory: .asv
+          
       - name: Compare HEAD with main if PR
         if: github.event_name == 'pull_request_target'
         continue-on-error: true # TODO: step failed sporadically while testing


### PR DESCRIPTION
This should stop the stardis-benchmarks repo from being overwritten. The workflow pushes new commits to a .asv subdirectory instead of the root of the repository. 