### PR TITLE
Internal speedup for calculating line opacities

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -519,7 +519,7 @@ def calc_alan_entries(
         np.abs(delta_nus), doppler_widths_at_depth_point, gammas_at_depth_point
     )
 
-    return np.sum(phis * alphas_at_depth_point)
+    return np.sum(phis * alphas_at_depth_point, axis=0)
 
 
 def calc_alphas(
@@ -593,9 +593,7 @@ def calc_alphas(
         stellar_radiation_field.frequencies,
         opacity_config.line,
     )
-    stellar_radiation_field.opacities.opacities_dict[
-        "alpha_line_at_nu"
-    ] = alpha_line_at_nu
+    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -593,9 +593,9 @@ def calc_alphas(
         stellar_radiation_field.frequencies,
         opacity_config.line,
     )
-    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
-        alpha_line_at_nu
-    )
+    stellar_radiation_field.opacities.opacities_dict[
+        "alpha_line_at_nu"
+    ] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -593,7 +593,9 @@ def calc_alphas(
         stellar_radiation_field.frequencies,
         opacity_config.line,
     )
-    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = alpha_line_at_nu
+    stellar_radiation_field.opacities.opacities_dict[
+        "alpha_line_at_nu"
+    ] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-from tqdm.notebook import tqdm
 
 import numba
 


### PR DESCRIPTION
I changed some code to use vectorization and appropriate broadcasting to eliminate some for loops. For an 1000 angstrom wide spectrum with 0.01 angstrom wide bins, this reduces the calculation time by a factor of ~2. Considering that this is most computationally expensive part of the code, this offers a substantial speedup to stardis. 

This change doesn't seem to show much in the benchmarks because we use a very small simulation in that case. This mainly gives significant speedups for large simulations that calculate many lines at many frequency bins. 