### PR TITLE
change prepare_atom_data() call to work with tardis restructure

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -87,7 +87,10 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
                 ]
             )
             + 1,
-        )
+        ),
+        line_interaction_type="macroatom",
+        nlte_species=[],
+        continuum_interaction_species=[],
     )
     # plasma
     stellar_plasma = create_stellar_plasma(stellar_model, adata, config)


### PR DESCRIPTION
Stardis uses up to date tardis. A recent tardis update changed the prepare_atom_data() function to require additional arguments. This PR makes stardis run again by adding the required arguments to the function call, and should be identical to previous behavior. 