### PR TITLE
Cleanup calculate broadening

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -582,9 +582,9 @@ def calc_alphas(
         stellar_radiation_field.frequencies,
         opacity_config.line,
     )
-    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
-        alpha_line_at_nu
-    )
+    stellar_radiation_field.opacities.opacities_dict[
+        "alpha_line_at_nu"
+    ] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -401,6 +401,7 @@ def calc_alpha_line_at_nu(
     lines_sorted_in_range = lines_sorted[
         lines_sorted.nu.between(line_nu_min, line_nu_max)
     ]
+    line_nus = lines_sorted_in_range.nu.to_numpy()
 
     if use_vald:
         alphas_and_nu = stellar_plasma.alpha_line_from_linelist.sort_values("nu")
@@ -413,7 +414,7 @@ def calc_alpha_line_at_nu(
         .to_numpy()
     )
 
-    line_nus, gammas, doppler_widths = calculate_broadening(
+    gammas, doppler_widths = calculate_broadening(
         lines_sorted_in_range,
         stellar_model,
         stellar_plasma,

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -419,7 +419,7 @@ def calc_alpha_line_at_nu(
         stellar_model,
         stellar_plasma,
         line_opacity_config.broadening,
-    )
+    )  # This can be further improved by only calculating the broadening for the lines that are within the range.
 
     alpha_line_at_nu = np.zeros((stellar_model.no_of_depth_points, len(tracing_nus)))
 

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -11,7 +11,6 @@ from stardis.radiation_field.opacities.opacities_solvers.broadening import (
 from stardis.radiation_field.opacities.opacities_solvers.voigt import voigt_profile
 from stardis.radiation_field.opacities.opacities_solvers.util import (
     sigma_file,
-    map_items_to_indices,
     get_number_density,
 )
 
@@ -398,10 +397,6 @@ def calc_alpha_line_at_nu(
             right_on=["atomic_number", "ion_number", "level_number"],
         ).rename(columns={"energy": "level_energy_upper"})
 
-    line_cols = map_items_to_indices(
-        lines.columns.to_list()
-    )  ###TODO: Fix this map_items_to_indices. Probably remove the function.
-
     lines_sorted = lines.sort_values("nu")
     lines_sorted_in_range = lines_sorted[
         lines_sorted.nu.between(line_nu_min, line_nu_max)
@@ -419,8 +414,7 @@ def calc_alpha_line_at_nu(
     )
 
     line_nus, gammas, doppler_widths = calculate_broadening(
-        lines_sorted_in_range.to_numpy(),
-        line_cols,
+        lines_sorted_in_range,
         stellar_model,
         stellar_plasma,
         line_opacity_config.broadening,

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -708,10 +708,7 @@ def calculate_broadening(
     doppler_widths = calc_doppler_width(
         lines.nu.values[:, np.newaxis],
         stellar_model.temperatures.value,
-        stellar_plasma.atomic_mass.values[
-            lines.atomic_number.values - 1,
-            np.newaxis,
-        ],
+        stellar_plasma.atomic_mass.loc[lines.atomic_number].values[:, np.newaxis],
     )
 
     return gammas, doppler_widths

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -740,4 +740,4 @@ def calculate_broadening(
                 atomic_masses.iloc[lines.atomic_number.iloc[i] - 1],
             )
 
-    return lines.nu.values, gammas, doppler_widths
+    return gammas, doppler_widths

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -667,37 +667,15 @@ def calculate_broadening(
 
     Parameters
     ----------
-    lines_array :
-        Array containing each line and properties of the line.
-    line_cols : dict
-        Matches the name of a quantity to its column index in lines_array.
-    no_depth_points : int
-        Number of depth pointss.
-    atomic_masses : numpy.ndarray
-        Atomic mass of all elements included in the simulation.
-    electron_densities : numpy.ndarray
-        Electron density at each depth point.
-    temperatures : numpy.ndarray
-        Temperature at each depth point.
-    h_densities : numpy.ndarray
-        Number density of hydrogen at each depth point.
-    linear_stark : bool, optional
-        True if linear Stark broadening is to be considered, otherwise False.
-        By default True.
-    quadratic_stark : bool, optional
-        True if quadratic Stark broadening is to be considered, otherwise
-        False. By default True.
-    van_der_waals : bool, optional
-        True if Van Der Waals broadening is to be considered, otherwise False.
-        By default True.
-    radiation : bool, optional
-        True if radiation broadening is to be considered, otherwise False.
-        By default True.
+    lines : DataFrame
+        Dataframe of the lines to calculate broadening for.
+    stellar_model : stardis.model.base.StellarModel
+    stellar_plasma : tardis.plasma.base.BasePlasma
+    broadening_line_opacity_config : tardis.io.configuration.config_reader.Configuration
+        Broadening methods section of the line opacity section of the STARDIS configuration.
 
     Returns
     -------
-    line_nus : numpy.ndarray
-        Frequency of each line.
     gammas : numpy.ndarray
         Array of shape (no_of_lines, no_depth_points). Collisional broadening
         parameter of each line at each depth point.

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -543,7 +543,7 @@ def calc_gamma_van_der_waals_cuda(
     return cp.asnumpy(res) if ret_np_ndarray else res
 
 
-# @numba.njit
+@numba.njit
 def calc_gamma(
     atomic_number,
     ion_number,
@@ -607,7 +607,9 @@ def calc_gamma(
     n_eff_upper = calc_n_effective(ion_number, ionization_energy, upper_level_energy)
     n_eff_lower = calc_n_effective(ion_number, ionization_energy, lower_level_energy)
 
-    gamma_linear_stark = np.zeros((len(atomic_number), len(electron_density)))
+    gamma_linear_stark = np.zeros(
+        (len(atomic_number), len(electron_density)), dtype=float
+    )
     h_indices = np.where(atomic_number == 1)[0]
     if linear_stark:  # only for hydrogen # why not all hydrogenic?
         gamma_linear_stark[h_indices, :] = calc_gamma_linear_stark(
@@ -625,7 +627,7 @@ def calc_gamma(
             temperature,
         )
     else:
-        gamma_quadratic_stark = 0
+        gamma_quadratic_stark = np.zeros_like(gamma_linear_stark)
 
     if van_der_waals:
         gamma_van_der_waals = calc_gamma_van_der_waals(
@@ -637,12 +639,12 @@ def calc_gamma(
             h_mass,
         )
     else:
-        gamma_van_der_waals = 0
+        gamma_van_der_waals = np.zeros_like(gamma_linear_stark)
 
     if radiation:
         gamma_radiation = A_ul
     else:
-        gamma_radiation = 0
+        gamma_radiation = np.zeros_like(gamma_linear_stark)
 
     gamma = (
         gamma_linear_stark
@@ -703,7 +705,6 @@ def calculate_broadening(
         Array of shape (no_of_lines, no_depth_points). Doppler width of each
         line at each depth point.
     """
-
     linear_stark = "linear_stark" in broadening_line_opacity_config
     quadratic_stark = "quadratic_stark" in broadening_line_opacity_config
     van_der_waals = "van_der_waals" in broadening_line_opacity_config

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -710,11 +710,6 @@ def calculate_broadening(
     van_der_waals = "van_der_waals" in broadening_line_opacity_config
     radiation = "radiation" in broadening_line_opacity_config
 
-    h_mass = stellar_plasma.atomic_mass.loc[1]
-    temperatures = stellar_model.temperatures.value
-    h_densities = stellar_plasma.ion_number_density.loc[1, 0]
-    electron_densities = stellar_plasma.electron_densities
-
     gammas = calc_gamma(
         atomic_number=lines.atomic_number.values[:, np.newaxis],
         ion_number=lines.ion_number.values[:, np.newaxis] + 1,
@@ -722,10 +717,10 @@ def calculate_broadening(
         upper_level_energy=lines.level_energy_upper.values[:, np.newaxis],
         lower_level_energy=lines.level_energy_lower.values[:, np.newaxis],
         A_ul=lines.A_ul.values[:, np.newaxis],
-        electron_density=electron_densities.values,
-        temperature=temperatures,
-        h_density=h_densities.values,
-        h_mass=h_mass,
+        electron_density=stellar_plasma.electron_densities.values,
+        temperature=stellar_model.temperatures.value,
+        h_density=stellar_plasma.ion_number_density.loc[1, 0].values,
+        h_mass=stellar_plasma.atomic_mass.loc[1],
         linear_stark=linear_stark,
         quadratic_stark=quadratic_stark,
         van_der_waals=van_der_waals,
@@ -734,7 +729,7 @@ def calculate_broadening(
 
     doppler_widths = calc_doppler_width(
         lines.nu.values[:, np.newaxis],
-        temperatures,
+        stellar_model.temperatures.value,
         stellar_plasma.atomic_mass.values[
             lines.atomic_number.values - 1,
             np.newaxis,

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -711,7 +711,6 @@ def calculate_broadening(
     h_mass = stellar_plasma.atomic_mass.loc[1]
     temperatures = stellar_model.temperatures.value
     h_densities = stellar_plasma.ion_number_density.loc[1, 0]
-    atomic_masses = stellar_plasma.atomic_mass
     electron_densities = stellar_plasma.electron_densities
 
     for i in range(len(lines)):
@@ -734,10 +733,13 @@ def calculate_broadening(
                 radiation=radiation,
             )
 
-            doppler_widths[i, j] = calc_doppler_width(
-                lines.nu.iloc[i],
-                temperatures[j],
-                atomic_masses.iloc[lines.atomic_number.iloc[i] - 1],
-            )
+    doppler_widths = calc_doppler_width(
+        lines.nu.values[:, np.newaxis],
+        temperatures,
+        stellar_plasma.atomic_mass.values[
+            lines.atomic_number.values - 1,
+            np.newaxis,
+        ],
+    )
 
     return gammas, doppler_widths

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacities_solvers.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_opacities_solvers.py
@@ -13,5 +13,5 @@ def test_calc_alpha_line_at_nu_with_broadening(
         example_tracing_nus,
         example_config_broadening.opacity.line,
     )
-    assert len(gammas) == len(doppler_widths)
+    assert gammas.shape == doppler_widths.shape
     assert len(alpha_line_at_nu) == example_stellar_model.no_of_depth_points

--- a/stardis/radiation_field/opacities/opacities_solvers/util.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/util.py
@@ -51,30 +51,6 @@ def sigma_file(tracing_lambdas, temperatures, fpath):
     return sigmas
 
 
-def map_items_to_indices(items):
-    """
-    Creates dictionary matching quantities in lines dataframe to their indices.
-
-    Parameters
-    ----------
-    items : list
-        List of column names.
-
-    Returns
-    -------
-    items_dict : dict
-    """
-    items_dict = Dict.empty(
-        key_type=types.unicode_type,
-        value_type=types.int64,
-    )
-
-    for i, item in enumerate(items):
-        items_dict[item] = i
-
-    return items_dict
-
-
 def get_number_density(stellar_plasma, spec):
     """
     Computes number density, atomic number, and ion number for an opacity

--- a/stardis/tests/stardis_test_config.yml
+++ b/stardis/tests/stardis_test_config.yml
@@ -5,16 +5,14 @@ model:
     fname: docs/quickstart/sun.mod
     final_atomic_number: 5
 opacity:
-    file:
-        Hminus_bf: docs/quickstart/h_minus_cross_section_wbr.dat
     bf:
         H_I: {}
     ff:
         H_I: {}
-    disable_electron_scattering: False
+    disable_electron_scattering: True
     line:
         disable: False
-        broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
+        broadening: []
         min: 6560 AA
         max: 6570 AA
 no_of_thetas: 1

--- a/stardis/tests/stardis_test_config_broadening.yml
+++ b/stardis/tests/stardis_test_config_broadening.yml
@@ -5,6 +5,8 @@ model:
     fname: docs/quickstart/sun.mod
     final_atomic_number: 5
 opacity:
+    file:
+        Hminus_bf: docs/quickstart/h_minus_cross_section_wbr.dat
     bf:
         H_I: {}
     ff:


### PR DESCRIPTION
The broadening calculation needed a lot of cleaning. This is the beginning of that cleaning/speedup. A large portion of the PR is getting rid of things being saved to variables and then immediately used in functions, or things being returned by functions for no reason, or things being converted to numpy arrays from dataframes and then being accessed in odd ways that make far more sense to be located directly in the dataframes. 

Another part of the pr is getting rid of the nested for loop inside the function. The calculations are now done with appropriate array broadcasting. 