### PR TITLE
fix bug with last depth point out of bounds error

### DIFF
--- a/stardis/base.py
+++ b/stardis/base.py
@@ -104,7 +104,12 @@ def run_stardis(config_fname, tracing_lambdas_or_nus):
         opacity_config=config.opacity,
     )
 
-    raytrace(stellar_model, stellar_radiation_field, no_of_thetas=config.no_of_thetas)
+    raytrace(
+        stellar_model,
+        stellar_radiation_field,
+        no_of_thetas=config.no_of_thetas,
+        parallel_config=config.parallel,
+    )
 
     return STARDISOutput(
         config.result_options, stellar_model, stellar_plasma, stellar_radiation_field

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -5,6 +5,9 @@ properties:
     stardis_config_version:
         enum:
         - 1.0
+    parallel:
+        type: boolean
+        default: false
     atom_data:
         type: string
     model:

--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -19,6 +19,9 @@ EXAMPLE_CONF_PATH = Path(__file__).parent / "tests" / "stardis_test_config.yml"
 EXAMPLE_CONF_PATH_BROADENING = (
     Path(__file__).parent / "tests" / "stardis_test_config_broadening.yml"
 )
+EXAMPLE_CONF_PATH_PARALLEL = (
+    Path(__file__).parent / "tests" / "stardis_test_config_parallel.yml"
+)
 
 
 @pytest.fixture(scope="session")
@@ -43,6 +46,12 @@ def example_config():
 @pytest.fixture(scope="session")
 def example_config_broadening():
     config_dict = validate_yaml(EXAMPLE_CONF_PATH_BROADENING, schemapath=SCHEMA_PATH)
+    return Configuration(config_dict)
+
+
+@pytest.fixture(scope="session")
+def example_config_parallel():
+    config_dict = validate_yaml(EXAMPLE_CONF_PATH_PARALLEL, schemapath=SCHEMA_PATH)
     return Configuration(config_dict)
 
 
@@ -133,6 +142,33 @@ def example_stellar_radiation_field_broadening(
 
 
 @pytest.fixture(scope="session")
+def example_stellar_radiation_field_parallel(
+    example_stellar_model,
+    example_config_parallel,
+    example_tracing_nus,
+    example_stellar_plasma,
+):
+    stellar_radiation_field = RadiationField(
+        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model
+    )
+
+    calc_alphas(
+        stellar_plasma=example_stellar_plasma,
+        stellar_model=example_stellar_model,
+        stellar_radiation_field=stellar_radiation_field,
+        opacity_config=example_config_parallel.opacity,
+    )
+
+    raytrace(
+        example_stellar_model,
+        stellar_radiation_field,
+        no_of_thetas=example_config_parallel.no_of_thetas,
+        parallel_config=example_config_parallel.parallel,
+    )
+    return stellar_radiation_field
+
+
+@pytest.fixture(scope="session")
 def example_stardis_output(
     example_stellar_model,
     example_stellar_plasma,
@@ -159,4 +195,19 @@ def example_stardis_output_broadening(
         example_stellar_model,
         example_stellar_plasma,
         example_stellar_radiation_field_broadening,
+    )
+
+
+@pytest.fixture(scope="session")
+def example_stardis_output_parallel(
+    example_stellar_model,
+    example_stellar_plasma,
+    example_stellar_radiation_field_parallel,
+    example_config_parallel,
+):
+    return STARDISOutput(
+        example_config_parallel.result_options,
+        example_stellar_model,
+        example_stellar_plasma,
+        example_stellar_radiation_field_parallel,
     )

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -1,6 +1,5 @@
 import numba
 import numpy as np
-from tqdm.notebook import tqdm
 
 
 @numba.njit(parallel=True)
@@ -122,10 +121,11 @@ def single_theta_trace_parallel(
     )
     no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
 
-    ###TODO: Generalize this for source functions other than blackbody that may require args other than frequency and temperature
     source = source_function(tracing_nus, temps)
     I_nu_theta = np.zeros((no_of_depth_gaps + 1, len(tracing_nus)))
-    I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
+    I_nu_theta[0] = source[
+        0
+    ]  # the innermost depth point is approximated as a blackbody
 
     w0, w1, w2 = calc_weights_parallel(taus)
 
@@ -221,10 +221,11 @@ def single_theta_trace(
     )
     no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
 
-    ###TODO: Generalize this for source functions other than blackbody that may require args other than frequency and temperature
     source = source_function(tracing_nus, temps)
-    I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
-    I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
+    I_nu_theta = np.zeros((no_of_depth_gaps + 1, len(tracing_nus)))
+    I_nu_theta[0] = source[
+        0
+    ]  # the innermost depth point is approximated as a blackbody
 
     # Solve for all the weights and prefactors except the last jump which would go out of bounds
     w0, w1, w2 = calc_weights(taus)

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 @numba.njit()
-def calc_weights_parallel(delta_tau):
+def calc_weights(delta_tau):
     """
     Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
 
@@ -36,39 +36,39 @@ def calc_weights_parallel(delta_tau):
     return w0, w1, w2
 
 
-def calc_weights(delta_tau):
-    """
-    Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
+# def calc_weights(delta_tau):
+#     """
+#     Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
 
-    Parameters
-    ----------
-    delta_tau : float
-        Total optical depth.
+#     Parameters
+#     ----------
+#     delta_tau : float
+#         Total optical depth.
 
-    Returns
-    -------
-    w0 : float
-    w1 : float
-    w2: float
-    """
-    w0 = np.ones_like(delta_tau)
-    w1 = np.ones_like(delta_tau)
-    w2 = np.ones_like(delta_tau) * 2.0
+#     Returns
+#     -------
+#     w0 : float
+#     w1 : float
+#     w2: float
+#     """
+#     w0 = np.ones_like(delta_tau)
+#     w1 = np.ones_like(delta_tau)
+#     w2 = np.ones_like(delta_tau) * 2.0
 
-    mask1 = delta_tau < 5e-4
-    mask2 = delta_tau > 50
-    mask3 = ~np.logical_or(mask1, mask2)
+#     mask1 = delta_tau < 5e-4
+#     mask2 = delta_tau > 50
+#     mask3 = ~np.logical_or(mask1, mask2)
 
-    w0[mask1] = delta_tau[mask1] * (1 - delta_tau[mask1] / 2)
-    w1[mask1] = delta_tau[mask1] ** 2 * (0.5 - delta_tau[mask1] / 3)
-    w2[mask1] = delta_tau[mask1] ** 3 * (1 / 3 - delta_tau[mask1] / 4)
+#     w0[mask1] = delta_tau[mask1] * (1 - delta_tau[mask1] / 2)
+#     w1[mask1] = delta_tau[mask1] ** 2 * (0.5 - delta_tau[mask1] / 3)
+#     w2[mask1] = delta_tau[mask1] ** 3 * (1 / 3 - delta_tau[mask1] / 4)
 
-    exp_delta_tau = np.exp(-delta_tau[mask3])
-    w0[mask3] = 1 - exp_delta_tau
-    w1[mask3] = w0[mask3] - delta_tau[mask3] * exp_delta_tau
-    w2[mask3] = 2 * w1[mask3] - delta_tau[mask3] * delta_tau[mask3] * exp_delta_tau
+#     exp_delta_tau = np.exp(-delta_tau[mask3])
+#     w0[mask3] = 1 - exp_delta_tau
+#     w1[mask3] = w0[mask3] - delta_tau[mask3] * exp_delta_tau
+#     w2[mask3] = 2 * w1[mask3] - delta_tau[mask3] * delta_tau[mask3] * exp_delta_tau
 
-    return w0, w1, w2
+#     return w0, w1, w2
 
 
 @numba.njit(parallel=True)

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -102,18 +102,11 @@ def single_theta_trace(
                     / (taus[i, j] + taus[i, j + 1])
                 )
 
-            else:  # handle the last depth point
-                second_term = (
-                    w1
-                    * (
-                        -(source[j + 1, i] - source[j, i])
-                        * (taus[i, j + 1] / taus[i, j])
-                    )
-                    / (taus[i, j] + taus[i, j + 1])
-                )
+            else:  # handle the last depth point, assuming the same source and tau as the preceeding value
+                second_term = w1 * (-(source[j + 1, i] - source[j, i]))
                 third_term = w2 * (
                     (((source[j, i] - source[j + 1, i]) / taus[i, j]))
-                    / (taus[i, j] + taus[i, j + 1])
+                    / (2 * taus[i, j])
                 )
 
             I_nu_theta[j + 1, i] = (

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -245,7 +245,7 @@ def single_theta_trace(
 
 
 def raytrace(
-    stellar_model, stellar_radiation_field, no_of_thetas=20, parallel_config=None
+    stellar_model, stellar_radiation_field, no_of_thetas=20, parallel_config=False
 ):
     """
     Raytraces over many angles and integrates to get flux using the midpoint

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -1,5 +1,6 @@
 import numba
 import numpy as np
+from tqdm.notebook import tqdm
 
 
 @numba.njit
@@ -18,20 +19,23 @@ def calc_weights(delta_tau):
     w1 : float
     w2: float
     """
+    w0 = np.ones_like(delta_tau)
+    w1 = np.ones_like(delta_tau)
+    w2 = np.ones_like(delta_tau) * 2.0
 
-    if delta_tau < 5e-4:
-        w0 = delta_tau * (1 - delta_tau / 2)
-        w1 = delta_tau**2 * (0.5 - delta_tau / 3)
-        w2 = delta_tau**3 * (1 / 3 - delta_tau / 4)
-    elif delta_tau > 50:
-        w0 = 1.0
-        w1 = 1.0
-        w2 = 2.0
-    else:
-        exp_delta_tau = np.exp(-delta_tau)
-        w0 = 1 - exp_delta_tau
-        w1 = w0 - delta_tau * exp_delta_tau
-        w2 = 2 * w1 - delta_tau * delta_tau * exp_delta_tau
+    mask1 = delta_tau < 5e-4
+    mask2 = delta_tau > 50
+    mask3 = ~np.logical_or(mask1, mask2)
+
+    w0[mask1] = delta_tau[mask1] * (1 - delta_tau[mask1] / 2)
+    w1[mask1] = delta_tau[mask1] ** 2 * (0.5 - delta_tau[mask1] / 3)
+    w2[mask1] = delta_tau[mask1] ** 3 * (1 / 3 - delta_tau[mask1] / 4)
+
+    exp_delta_tau = np.exp(-delta_tau[mask3])
+    w0[mask3] = 1 - exp_delta_tau
+    w1[mask3] = w0[mask3] - delta_tau[mask3] * exp_delta_tau
+    w2[mask3] = 2 * w1[mask3] - delta_tau[mask3] * delta_tau[mask3] * exp_delta_tau
+
     return w0, w1, w2
 
 
@@ -70,7 +74,9 @@ def single_theta_trace(
     """
     # Need to calculate a mean opacity for the traversal between points. Linearly interporlating, but could have a choice for interpolation scheme here.
     mean_alphas = (alphas[1:] + alphas[:-1]) * 0.5
-    taus = mean_alphas.T * geometry_dist_to_next_depth_point / np.cos(theta)
+    taus = (
+        mean_alphas * geometry_dist_to_next_depth_point.reshape(-1, 1) / np.cos(theta)
+    )
     no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
 
     ###TODO: Generalize this for source functions other than blackbody that may require args other than frequency and temperature
@@ -78,40 +84,46 @@ def single_theta_trace(
     I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
     I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
 
-    for i in range(len(tracing_nus)):  # iterating over nus (columns)
-        for j in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
+    for gap_index in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
 
-            w0, w1, w2 = calc_weights(taus[i, j])
+        w0, w1, w2 = calc_weights(taus[gap_index, :])
 
-            if j < no_of_depth_gaps - 1:
-                second_term = (
-                    w1
-                    * (
-                        (source[j + 1, i] - source[j + 2, i])
-                        * (taus[i, j] / taus[i, j + 1])
-                        - (source[j + 1, i] - source[j, i])
-                        * (taus[i, j + 1] / taus[i, j])
-                    )
-                    / (taus[i, j] + taus[i, j + 1])
+        if gap_index < no_of_depth_gaps - 1:
+            second_term = (
+                w1
+                * (
+                    (source[gap_index + 1] - source[gap_index + 2])
+                    * (taus[gap_index, :] / taus[gap_index + 1, :])
+                    - (source[gap_index + 1] - source[gap_index])
+                    * (taus[gap_index + 1, :] / taus[gap_index, :])
                 )
-                third_term = w2 * (
-                    (
-                        ((source[j + 2, i] - source[j + 1, i]) / taus[i, j + 1])
-                        + ((source[j, i] - source[j + 1, i]) / taus[i, j])
-                    )
-                    / (taus[i, j] + taus[i, j + 1])
-                )
-
-            else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
-                second_term = 0
-                third_term = w2 * (source[j, i] - source[j + 1, i]) / taus[i, j] ** 2
-
-            I_nu_theta[j + 1, i] = (
-                (1 - w0) * I_nu_theta[j, i]
-                + w0 * source[j + 1, i]
-                + second_term
-                + third_term
+                / (taus[gap_index, :] + taus[gap_index + 1, :])
             )
+            third_term = w2 * (
+                (
+                    (
+                        (source[gap_index + 2] - source[gap_index + 1])
+                        / taus[gap_index + 1, :]
+                    )
+                    + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
+                )
+                / (taus[gap_index, :] + taus[gap_index + 1, :])
+            )
+
+        else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
+            second_term = np.zeros_like(w0)
+            third_term = (
+                w2
+                * (source[gap_index] - source[gap_index + 1])
+                / taus[gap_index, :] ** 2
+            )
+
+        I_nu_theta[gap_index + 1] = (
+            (1 - w0) * I_nu_theta[gap_index]
+            + w0 * source[gap_index + 1]
+            + second_term
+            + third_term
+        )
 
     return I_nu_theta
 
@@ -142,7 +154,7 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20):
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
 
     ###TODO: Thetas should probably be held by the model? Then can be passed in from there.
-    for theta in thetas:
+    for theta in tqdm(thetas):
         weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
         stellar_radiation_field.F_nu += weight * single_theta_trace(
             stellar_model.geometry.dist_to_next_depth_point,

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -148,15 +148,15 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20):
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
 
     ###TODO: Thetas should probably be held by the model? Then can be passed in from there.
-    # for theta in tqdm(thetas):
-    weight = 2 * np.pi * dtheta * np.sin(thetas) * np.cos(thetas)
-    stellar_radiation_field.F_nu += weight * single_theta_trace(
-        stellar_model.geometry.dist_to_next_depth_point,
-        stellar_model.temperatures.value.reshape(-1, 1),
-        stellar_radiation_field.opacities.total_alphas,
-        stellar_radiation_field.frequencies,
-        thetas,
-        stellar_radiation_field.source_function,
-    )
+    for theta in tqdm(thetas):
+        weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
+        stellar_radiation_field.F_nu += weight * single_theta_trace(
+            stellar_model.geometry.dist_to_next_depth_point,
+            stellar_model.temperatures.value.reshape(-1, 1),
+            stellar_radiation_field.opacities.total_alphas,
+            stellar_radiation_field.frequencies,
+            theta,
+            stellar_radiation_field.source_function,
+        )
 
     return stellar_radiation_field.F_nu

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -1,10 +1,9 @@
 import numba
 import numpy as np
-from tqdm.notebook import tqdm
 
 
 @numba.njit()
-def calc_weights(delta_tau):
+def calc_weights_parallel(delta_tau):
     """
     Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
 
@@ -37,8 +36,43 @@ def calc_weights(delta_tau):
     return w0, w1, w2
 
 
+def calc_weights(delta_tau):
+    """
+    Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
+
+    Parameters
+    ----------
+    delta_tau : float
+        Total optical depth.
+
+    Returns
+    -------
+    w0 : float
+    w1 : float
+    w2: float
+    """
+    w0 = np.ones_like(delta_tau)
+    w1 = np.ones_like(delta_tau)
+    w2 = np.ones_like(delta_tau) * 2.0
+
+    mask1 = delta_tau < 5e-4
+    mask2 = delta_tau > 50
+    mask3 = ~np.logical_or(mask1, mask2)
+
+    w0[mask1] = delta_tau[mask1] * (1 - delta_tau[mask1] / 2)
+    w1[mask1] = delta_tau[mask1] ** 2 * (0.5 - delta_tau[mask1] / 3)
+    w2[mask1] = delta_tau[mask1] ** 3 * (1 / 3 - delta_tau[mask1] / 4)
+
+    exp_delta_tau = np.exp(-delta_tau[mask3])
+    w0[mask3] = 1 - exp_delta_tau
+    w1[mask3] = w0[mask3] - delta_tau[mask3] * exp_delta_tau
+    w2[mask3] = 2 * w1[mask3] - delta_tau[mask3] * delta_tau[mask3] * exp_delta_tau
+
+    return w0, w1, w2
+
+
 @numba.njit(parallel=True)
-def single_theta_trace(
+def single_theta_trace_parallel(
     geometry_dist_to_next_depth_point,
     temps,
     alphas,
@@ -86,7 +120,7 @@ def single_theta_trace(
         no_of_depth_gaps - 1
     ):  # iterating over depth_gaps (rows)
 
-        w0, w1, w2 = calc_weights(taus[gap_index, :])
+        w0, w1, w2 = calc_weights_parallel(taus[gap_index, :])
 
         second_term = (
             w1
@@ -115,14 +149,104 @@ def single_theta_trace(
             + third_term
         )
 
-    w0, w1, w2 = calc_weights(taus[-1, :])
+    w0, w1, w2 = calc_weights_parallel(taus[-1, :])
     third_term = w2 * (source[-2] - source[-1]) / taus[-1, :] ** 2
     I_nu_theta[-1] = (1 - w0) * I_nu_theta[-2] + w0 * source[-1] + third_term
 
     return I_nu_theta
 
 
-def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20):
+def single_theta_trace(
+    geometry_dist_to_next_depth_point,
+    temps,
+    alphas,
+    tracing_nus,
+    theta,
+    source_function,
+):
+    """
+    Performs ray tracing at an angle following van Noort 2001 eq 14.
+
+    Parameters
+    ----------
+    geometry_dist_to_next_depth_point : numpy.ndarray
+        Distance to next depth point in geometry column as a numpy array from the finite volume model.
+    temps : numpy.ndarray
+        Temperatures in K of all depth point. Note that array must
+        be transposed.
+    alphas : numpy.ndarray
+        Array of shape (no_of_depth_points, no_of_frequencies). Total opacity at
+        each depth point for each frequency in tracing_nus.
+    tracing_nus : astropy.unit.quantity.Quantity
+        Numpy array of frequencies used for ray tracing with units of Hz.
+    theta : float
+        Angle that the ray makes with the normal/radial direction.
+
+    Returns
+    -------
+    I_nu_theta : numpy.ndarray
+        Array of shape (no_of_depth_points, no_of_frequencies). Output specific
+        intensity at each depth point for each frequency in tracing_nus.
+    """
+    # Need to calculate a mean opacity for the traversal between points. Linearly interporlating, but could have a choice for interpolation scheme here.
+    mean_alphas = (alphas[1:] + alphas[:-1]) * 0.5
+    taus = (
+        mean_alphas * geometry_dist_to_next_depth_point.reshape(-1, 1) / np.cos(theta)
+    )
+    no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
+
+    ###TODO: Generalize this for source functions other than blackbody that may require args other than frequency and temperature
+    source = source_function(tracing_nus, temps)
+    I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
+    I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
+
+    for gap_index in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
+
+        w0, w1, w2 = calc_weights(taus[gap_index, :])
+
+        if gap_index < no_of_depth_gaps - 1:
+            second_term = (
+                w1
+                * (
+                    (source[gap_index + 1] - source[gap_index + 2])
+                    * (taus[gap_index, :] / taus[gap_index + 1, :])
+                    - (source[gap_index + 1] - source[gap_index])
+                    * (taus[gap_index + 1, :] / taus[gap_index, :])
+                )
+                / (taus[gap_index, :] + taus[gap_index + 1, :])
+            )
+            third_term = w2 * (
+                (
+                    (
+                        (source[gap_index + 2] - source[gap_index + 1])
+                        / taus[gap_index + 1, :]
+                    )
+                    + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
+                )
+                / (taus[gap_index, :] + taus[gap_index + 1, :])
+            )
+
+        else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
+            second_term = np.zeros_like(w0)
+            third_term = (
+                w2
+                * (source[gap_index] - source[gap_index + 1])
+                / taus[gap_index, :] ** 2
+            )
+
+        I_nu_theta[gap_index + 1] = (
+            (1 - w0) * I_nu_theta[gap_index]
+            + w0 * source[gap_index + 1]
+            + second_term
+            + third_term
+        )
+
+    return I_nu_theta
+
+
+def raytrace(
+    stellar_model, stellar_radiation_field, no_of_thetas=20, parallel_config=None
+):
     """
     Raytraces over many angles and integrates to get flux using the midpoint
     rule.
@@ -148,15 +272,28 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20):
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
 
     ###TODO: Thetas should probably be held by the model? Then can be passed in from there.
-    for theta in tqdm(thetas):
-        weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
-        stellar_radiation_field.F_nu += weight * single_theta_trace(
-            stellar_model.geometry.dist_to_next_depth_point,
-            stellar_model.temperatures.value.reshape(-1, 1),
-            stellar_radiation_field.opacities.total_alphas,
-            stellar_radiation_field.frequencies,
-            theta,
-            stellar_radiation_field.source_function,
-        )
+    if parallel_config is False:
+        for theta in thetas:
+            weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
+            stellar_radiation_field.F_nu += weight * single_theta_trace(
+                stellar_model.geometry.dist_to_next_depth_point,
+                stellar_model.temperatures.value.reshape(-1, 1),
+                stellar_radiation_field.opacities.total_alphas,
+                stellar_radiation_field.frequencies,
+                theta,
+                stellar_radiation_field.source_function,
+            )
+
+    elif parallel_config:
+        for theta in thetas:
+            weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
+            stellar_radiation_field.F_nu += weight * single_theta_trace_parallel(
+                stellar_model.geometry.dist_to_next_depth_point,
+                stellar_model.temperatures.value.reshape(-1, 1),
+                stellar_radiation_field.opacities.total_alphas,
+                stellar_radiation_field.frequencies,
+                theta,
+                stellar_radiation_field.source_function,
+            )
 
     return stellar_radiation_field.F_nu

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -200,46 +200,40 @@ def single_theta_trace(
     I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
     I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
 
-    for gap_index in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
+    for gap_index in range(no_of_depth_gaps - 1):  # iterating over depth_gaps (rows)
 
         w0, w1, w2 = calc_weights(taus[gap_index, :])
 
-        if gap_index < no_of_depth_gaps - 1:
-            second_term = (
-                w1
-                * (
-                    (source[gap_index + 1] - source[gap_index + 2])
-                    * (taus[gap_index, :] / taus[gap_index + 1, :])
-                    - (source[gap_index + 1] - source[gap_index])
-                    * (taus[gap_index + 1, :] / taus[gap_index, :])
-                )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+        second_term = (
+            w1
+            * (
+                (source[gap_index + 1] - source[gap_index + 2])
+                * (taus[gap_index, :] / taus[gap_index + 1, :])
+                - (source[gap_index + 1] - source[gap_index])
+                * (taus[gap_index + 1, :] / taus[gap_index, :])
             )
-            third_term = w2 * (
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
+        third_term = w2 * (
+            (
                 (
-                    (
-                        (source[gap_index + 2] - source[gap_index + 1])
-                        / taus[gap_index + 1, :]
-                    )
-                    + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
+                    (source[gap_index + 2] - source[gap_index + 1])
+                    / taus[gap_index + 1, :]
                 )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+                + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
             )
-
-        else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
-            second_term = np.zeros_like(w0)
-            third_term = (
-                w2
-                * (source[gap_index] - source[gap_index + 1])
-                / taus[gap_index, :] ** 2
-            )
-
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
         I_nu_theta[gap_index + 1] = (
             (1 - w0) * I_nu_theta[gap_index]
             + w0 * source[gap_index + 1]
             + second_term
             + third_term
         )
+
+    w0, w1, w2 = calc_weights(taus[-1, :])
+    third_term = w2 * (source[-2] - source[-1]) / taus[-1, :] ** 2
+    I_nu_theta[-1] = (1 - w0) * I_nu_theta[-2] + w0 * source[-1] + third_term
 
     return I_nu_theta
 

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -103,11 +103,8 @@ def single_theta_trace(
                 )
 
             else:  # handle the last depth point, assuming the same source and tau as the preceeding value
-                second_term = w1 * (-(source[j + 1, i] - source[j, i]))
-                third_term = w2 * (
-                    (((source[j, i] - source[j + 1, i]) / taus[i, j]))
-                    / (2 * taus[i, j])
-                )
+                second_term = 0
+                third_term = w2 * (source[j, i] - source[j + 1, i]) / taus[i, j] ** 2
 
             I_nu_theta[j + 1, i] = (
                 (1 - w0) * I_nu_theta[j, i]

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -131,8 +131,8 @@ def single_theta_trace_parallel(
 
     # return I_nu_theta
     for nu_index in numba.prange(len(tracing_nus)):
-        for gap_index in range(no_of_depth_gaps - 1): 
-            #Start by solving all the weights and prefactors except the last jump which would go out of bounds
+        for gap_index in range(no_of_depth_gaps - 1):
+            # Start by solving all the weights and prefactors except the last jump which would go out of bounds
             second_term = (
                 w1[gap_index, nu_index]
                 * (

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -36,6 +36,7 @@ def calc_weights_parallel(delta_tau):
     return w0, w1, w2
 
 
+@numba.njit()
 def calc_weights(delta_tau):
     """
     Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
@@ -200,46 +201,40 @@ def single_theta_trace(
     I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
     I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
 
-    for gap_index in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
+    for gap_index in range(no_of_depth_gaps - 1):  # iterating over depth_gaps (rows)
 
         w0, w1, w2 = calc_weights(taus[gap_index, :])
 
-        if gap_index < no_of_depth_gaps - 1:
-            second_term = (
-                w1
-                * (
-                    (source[gap_index + 1] - source[gap_index + 2])
-                    * (taus[gap_index, :] / taus[gap_index + 1, :])
-                    - (source[gap_index + 1] - source[gap_index])
-                    * (taus[gap_index + 1, :] / taus[gap_index, :])
-                )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+        second_term = (
+            w1
+            * (
+                (source[gap_index + 1] - source[gap_index + 2])
+                * (taus[gap_index, :] / taus[gap_index + 1, :])
+                - (source[gap_index + 1] - source[gap_index])
+                * (taus[gap_index + 1, :] / taus[gap_index, :])
             )
-            third_term = w2 * (
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
+        third_term = w2 * (
+            (
                 (
-                    (
-                        (source[gap_index + 2] - source[gap_index + 1])
-                        / taus[gap_index + 1, :]
-                    )
-                    + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
+                    (source[gap_index + 2] - source[gap_index + 1])
+                    / taus[gap_index + 1, :]
                 )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+                + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
             )
-
-        else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
-            second_term = np.zeros_like(w0)
-            third_term = (
-                w2
-                * (source[gap_index] - source[gap_index + 1])
-                / taus[gap_index, :] ** 2
-            )
-
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
         I_nu_theta[gap_index + 1] = (
             (1 - w0) * I_nu_theta[gap_index]
             + w0 * source[gap_index + 1]
             + second_term
             + third_term
         )
+
+    w0, w1, w2 = calc_weights(taus[-1, :])
+    third_term = w2 * (source[-2] - source[-1]) / taus[-1, :] ** 2
+    I_nu_theta[-1] = (1 - w0) * I_nu_theta[-2] + w0 * source[-1] + third_term
 
     return I_nu_theta
 

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -102,7 +102,7 @@ def single_theta_trace(
                     / (taus[i, j] + taus[i, j + 1])
                 )
 
-            else:  # handle the last depth point, assuming the same source and tau as the preceeding value
+            else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
                 second_term = 0
                 third_term = w2 * (source[j, i] - source[j + 1, i]) / taus[i, j] ** 2
 

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -3,7 +3,7 @@ import numpy as np
 from tqdm.notebook import tqdm
 
 
-@numba.njit
+@numba.njit()
 def calc_weights(delta_tau):
     """
     Calculates w0 and w1 coefficients in van Noort 2001 eq 14.
@@ -23,23 +23,21 @@ def calc_weights(delta_tau):
     w1 = np.ones_like(delta_tau)
     w2 = np.ones_like(delta_tau) * 2.0
 
-    mask1 = delta_tau < 5e-4
-    mask2 = delta_tau > 50
-    mask3 = ~np.logical_or(mask1, mask2)
-
-    w0[mask1] = delta_tau[mask1] * (1 - delta_tau[mask1] / 2)
-    w1[mask1] = delta_tau[mask1] ** 2 * (0.5 - delta_tau[mask1] / 3)
-    w2[mask1] = delta_tau[mask1] ** 3 * (1 / 3 - delta_tau[mask1] / 4)
-
-    exp_delta_tau = np.exp(-delta_tau[mask3])
-    w0[mask3] = 1 - exp_delta_tau
-    w1[mask3] = w0[mask3] - delta_tau[mask3] * exp_delta_tau
-    w2[mask3] = 2 * w1[mask3] - delta_tau[mask3] * delta_tau[mask3] * exp_delta_tau
+    for i in range(delta_tau.shape[0]):
+        if delta_tau[i] < 5e-4:
+            w0[i] = delta_tau[i] * (1 - delta_tau[i] / 2)
+            w1[i] = delta_tau[i] ** 2 * (0.5 - delta_tau[i] / 3)
+            w2[i] = delta_tau[i] ** 3 * (1 / 3 - delta_tau[i] / 4)
+        elif delta_tau[i] < 50:
+            exp_delta_tau = np.exp(-delta_tau[i])
+            w0[i] = 1 - exp_delta_tau
+            w1[i] = w0[i] - delta_tau[i] * exp_delta_tau
+            w2[i] = 2 * w1[i] - delta_tau[i] * delta_tau[i] * exp_delta_tau
 
     return w0, w1, w2
 
 
-@numba.njit()
+@numba.njit(parallel=True)
 def single_theta_trace(
     geometry_dist_to_next_depth_point,
     temps,
@@ -81,49 +79,45 @@ def single_theta_trace(
 
     ###TODO: Generalize this for source functions other than blackbody that may require args other than frequency and temperature
     source = source_function(tracing_nus, temps)
-    I_nu_theta = np.ones((no_of_depth_gaps + 1, len(tracing_nus))) * np.nan
+    I_nu_theta = np.zeros((no_of_depth_gaps + 1, len(tracing_nus)))
     I_nu_theta[0] = source[0]  # the innermost depth point is the photosphere
 
-    for gap_index in range(no_of_depth_gaps):  # iterating over depth_gaps (rows)
+    for gap_index in numba.prange(
+        no_of_depth_gaps - 1
+    ):  # iterating over depth_gaps (rows)
 
         w0, w1, w2 = calc_weights(taus[gap_index, :])
 
-        if gap_index < no_of_depth_gaps - 1:
-            second_term = (
-                w1
-                * (
-                    (source[gap_index + 1] - source[gap_index + 2])
-                    * (taus[gap_index, :] / taus[gap_index + 1, :])
-                    - (source[gap_index + 1] - source[gap_index])
-                    * (taus[gap_index + 1, :] / taus[gap_index, :])
-                )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+        second_term = (
+            w1
+            * (
+                (source[gap_index + 1] - source[gap_index + 2])
+                * (taus[gap_index, :] / taus[gap_index + 1, :])
+                - (source[gap_index + 1] - source[gap_index])
+                * (taus[gap_index + 1, :] / taus[gap_index, :])
             )
-            third_term = w2 * (
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
+        third_term = w2 * (
+            (
                 (
-                    (
-                        (source[gap_index + 2] - source[gap_index + 1])
-                        / taus[gap_index + 1, :]
-                    )
-                    + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
+                    (source[gap_index + 2] - source[gap_index + 1])
+                    / taus[gap_index + 1, :]
                 )
-                / (taus[gap_index, :] + taus[gap_index + 1, :])
+                + ((source[gap_index] - source[gap_index + 1]) / taus[gap_index, :])
             )
-
-        else:  # handle the last depth point, assuming the same source as the preceeding value and tau as 0
-            second_term = np.zeros_like(w0)
-            third_term = (
-                w2
-                * (source[gap_index] - source[gap_index + 1])
-                / taus[gap_index, :] ** 2
-            )
-
+            / (taus[gap_index, :] + taus[gap_index + 1, :])
+        )
         I_nu_theta[gap_index + 1] = (
             (1 - w0) * I_nu_theta[gap_index]
             + w0 * source[gap_index + 1]
             + second_term
             + third_term
         )
+
+    w0, w1, w2 = calc_weights(taus[-1, :])
+    third_term = w2 * (source[-2] - source[-1]) / taus[-1, :] ** 2
+    I_nu_theta[-1] = (1 - w0) * I_nu_theta[-2] + w0 * source[-1] + third_term
 
     return I_nu_theta
 
@@ -154,15 +148,15 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20):
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
 
     ###TODO: Thetas should probably be held by the model? Then can be passed in from there.
-    for theta in tqdm(thetas):
-        weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
-        stellar_radiation_field.F_nu += weight * single_theta_trace(
-            stellar_model.geometry.dist_to_next_depth_point,
-            stellar_model.temperatures.value.reshape(-1, 1),
-            stellar_radiation_field.opacities.total_alphas,
-            stellar_radiation_field.frequencies,
-            theta,
-            stellar_radiation_field.source_function,
-        )
+    # for theta in tqdm(thetas):
+    weight = 2 * np.pi * dtheta * np.sin(thetas) * np.cos(thetas)
+    stellar_radiation_field.F_nu += weight * single_theta_trace(
+        stellar_model.geometry.dist_to_next_depth_point,
+        stellar_model.temperatures.value.reshape(-1, 1),
+        stellar_radiation_field.opacities.total_alphas,
+        stellar_radiation_field.frequencies,
+        thetas,
+        stellar_radiation_field.source_function,
+    )
 
     return stellar_radiation_field.F_nu

--- a/stardis/tests/stardis_test_config_broadening.yml
+++ b/stardis/tests/stardis_test_config_broadening.yml
@@ -22,5 +22,5 @@ opacity:
         vald_linelist: 
             use_linelist: False
             shortlist: False
-        broadening_range: 1 AA         
-no_of_thetas: 1
+        broadening_range: 3 AA         
+no_of_thetas: 10

--- a/stardis/tests/stardis_test_config_parallel.yml
+++ b/stardis/tests/stardis_test_config_parallel.yml
@@ -1,0 +1,23 @@
+stardis_config_version: 1.0
+parallel: True
+atom_data: kurucz_cd23_chianti_H_He.h5
+model:
+    type: marcs
+    fname: docs/quickstart/sun.mod
+    final_atomic_number: 5
+opacity:
+    bf:
+        H_I: {}
+    ff:
+        H_I: {}
+    disable_electron_scattering: False
+    line:
+        disable: True
+        broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
+        min: 6560 AA
+        max: 6570 AA
+        vald_linelist: 
+            use_linelist: False
+            shortlist: False
+        broadening_range: 5 AA         
+no_of_thetas: 10

--- a/stardis/tests/stardis_test_config_parallel.yml
+++ b/stardis/tests/stardis_test_config_parallel.yml
@@ -6,18 +6,22 @@ model:
     fname: docs/quickstart/sun.mod
     final_atomic_number: 5
 opacity:
+    file:
+        Hminus_bf: stardis/data/h_minus_bf_W1979.dat
+        Hminus_ff: stardis/data/h_minus_ff_B1987.dat
+        H2plus_bf: stardis/data/h2_plus_bf_S1994.dat
     bf:
         H_I: {}
     ff:
         H_I: {}
     disable_electron_scattering: False
     line:
-        disable: True
+        disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
         min: 6560 AA
         max: 6570 AA
         vald_linelist: 
             use_linelist: False
             shortlist: False
-        broadening_range: 5 AA         
+        broadening_range: 3 AA         
 no_of_thetas: 10

--- a/stardis/tests/test_stardis_full.py
+++ b/stardis/tests/test_stardis_full.py
@@ -15,11 +15,13 @@ def test_stardis_broadening_output(
 
 
 def test_stardis_parallel_output(
-    example_stardis_output_parallel, example_tracing_nus, example_stardis_output
+    example_stardis_output_parallel,
+    example_tracing_nus,
+    example_stardis_output_broadening,
 ):
     assert len(example_stardis_output_parallel.spectrum_nu) == len(example_tracing_nus)
     assert ~np.all(np.isnan(example_stardis_output_parallel.spectrum_nu))
     assert_allclose(
         example_stardis_output_parallel.spectrum_nu,
-        example_stardis_output.spectrum_nu,
+        example_stardis_output_broadening.spectrum_nu,
     )

--- a/stardis/tests/test_stardis_full.py
+++ b/stardis/tests/test_stardis_full.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 def test_stardis_output(example_stardis_output, example_tracing_nus):
     assert len(example_stardis_output.spectrum_nu) == len(example_tracing_nus)
 
@@ -8,3 +11,8 @@ def test_stardis_broadening_output(
     assert len(example_stardis_output_broadening.spectrum_nu) == len(
         example_tracing_nus
     )
+
+
+def test_stardis_parallel_output(example_stardis_output_parallel, example_tracing_nus):
+    assert len(example_stardis_output_parallel.spectrum_nu) == len(example_tracing_nus)
+    assert ~np.all(np.isnan(example_stardis_output_parallel.spectrum_nu))

--- a/stardis/tests/test_stardis_full.py
+++ b/stardis/tests/test_stardis_full.py
@@ -1,4 +1,5 @@
 import numpy as np
+from numpy.testing import assert_allclose
 
 
 def test_stardis_output(example_stardis_output, example_tracing_nus):
@@ -13,6 +14,12 @@ def test_stardis_broadening_output(
     )
 
 
-def test_stardis_parallel_output(example_stardis_output_parallel, example_tracing_nus):
+def test_stardis_parallel_output(
+    example_stardis_output_parallel, example_tracing_nus, example_stardis_output
+):
     assert len(example_stardis_output_parallel.spectrum_nu) == len(example_tracing_nus)
     assert ~np.all(np.isnan(example_stardis_output_parallel.spectrum_nu))
+    assert_allclose(
+        example_stardis_output_parallel.spectrum_nu,
+        example_stardis_output.spectrum_nu,
+    )


### PR DESCRIPTION
I made a mistake with PR #176 where I didn't correctly adapt the radiative transfer equation for the last calculation. It tried to access a tau out of bounds of the tau array. I didn't realize it because apparently the njit decorator can hide that and complete the calculation quietly anyway, probably accessing something else in memory that doesn't belong to the array. 

Good to know, and this gives us back a tiny bit more of the missing flux. 

I should mention, for adapting the equation I just used tau[j+1] = tau[j], which should be ok enough of an approximation. The other choice would be to have tau[j+1] = 0 (since you're not moving through any material anymore). If there are any strong opinions on this I would love to hear it. 

---------------------------------------

This PR got much bigger than it was before. It not introduces the start of parallelization into stardis. For a large simulation, this should help improve raytracing speed considerably. However, in order to support that, the code needed to be written to play better with numba. The code can't be efficient for both numba parallelization as well as single threading, so I wrote it in both ways. There's a config option to toggle whether you want to enable parallelization or not. This should also be extended to parallelize some of the opacity calculations in the future, but the main benefit of this is that for small simulations the most efficient way to do all of this is not to use numba at all, and just let numpy do the work. 