### PR TITLE
Update voigt profile and add documentation

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -114,9 +114,11 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     Calculates the Voigt profile, the convolution of a Lorentz profile
     and a Gaussian profile.
 
-    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf page 59, eqs 3.63, 3.71, and 3.72).
-    Without the 1/2pi factor, the scipy voigt profile is returned.
+    See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
+    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
+    https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see page 59, 3.71, and 3.72).
+    Without the 1/2pi factor in gamma, the scipy voigt profile is returned.
     There's a factor of 2 unaccounted for, but it's not clear where it comes from.
 
     Parameters

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,7 +48,9 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
+        1j
+        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
+        / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,7 +48,9 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
+        1j
+        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
+        / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -119,7 +121,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
     With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
     the scipy voigt profile is returned. I think this comes from the disagreements in the definition
-    of the voigt profile, (see page 59, 3.68, and 3.71).
+    of the voigt profile, (see page 59, 3.68, and 3.71 versus https://en.wikipedia.org/wiki/Voigt_profile).
 
 
     Parameters

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,9 +48,7 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j
-        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
-        / (0.75 + z**2 * (z**2 - 3.0))
+        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -119,9 +117,10 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see page 59, 3.71, and 3.72).
-    Without the 1/2pi factor in gamma, the scipy voigt profile is returned.
-    There's a factor of 2 unaccounted for, but it's not clear where it comes from.
+    With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
+    the scipy voigt profile is returned. I think this comes from the disagreements in the definition
+    of the voigt profile, (see page 59, 3.68, and 3.71).
+
 
     Parameters
     ----------
@@ -144,7 +143,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
         float(gamma),
     )
 
-    z = complex(delta_nu, gamma / (2 * PI)) / (doppler_width)
+    z = complex(delta_nu, gamma / (SQRT_PI * PI)) / (doppler_width)
     phi = _faddeeva(z).real / (SQRT_PI * doppler_width)
     return phi
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -119,7 +119,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
-    With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
+    With the modification to doppler width, and without the 1/pi**1.5 factor in gamma,
     the scipy voigt profile is returned. I think this comes from the disagreements in the definition
     of the voigt profile, (see page 59, 3.68, and 3.71 versus https://en.wikipedia.org/wiki/Voigt_profile).
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,9 +48,7 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j
-        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
-        / (0.75 + z**2 * (z**2 - 3.0))
+        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -116,6 +114,10 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     Calculates the Voigt profile, the convolution of a Lorentz profile
     and a Gaussian profile.
 
+    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi. Without the 1/2pi factor, the scipy voigt profile is returned.
+    There's a factor of 2 unaccounted for, but it's not clear where it comes from.
+
     Parameters
     ----------
     delta_nu : float
@@ -131,9 +133,13 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     phi : float
         Value of Voigt profile.
     """
-    delta_nu, doppler_width, gamma = float(delta_nu), float(doppler_width), float(gamma)
+    delta_nu, doppler_width, gamma = (
+        float(delta_nu),
+        float(doppler_width),
+        float(gamma),
+    )
 
-    z = complex(delta_nu, gamma / (4 * PI)) / doppler_width
+    z = complex(delta_nu, gamma / (2 * PI)) / (doppler_width)
     phi = _faddeeva(z).real / (SQRT_PI * doppler_width)
     return phi
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -115,7 +115,8 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     and a Gaussian profile.
 
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi. Without the 1/2pi factor, the scipy voigt profile is returned.
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf page 59, eqs 3.63, 3.71, and 3.72).
+    Without the 1/2pi factor, the scipy voigt profile is returned.
     There's a factor of 2 unaccounted for, but it's not clear where it comes from.
 
     Parameters


### PR DESCRIPTION
Our voigt profile disagrees with the scipy voigt profile by a couple of factors. This PR adds documentation to explain where our disagreements come, including references to where things are defined differently. It also changes the constant attached to our gamma passed in to the lorentzian, where I think the disagreement comes from a defined dispersion parameter versus the lorentzian gamma. It all still seems a bit nebulous, but this change gives us correct lines. I attach an h-alpha comparison to korg for comparison. 

![h-alpha_comparison](https://github.com/tardis-sn/stardis/assets/54691495/134f764e-58cc-4735-847c-0b960bdecdb0)


There's still some disagreement at the bottom of the line that comes from treating linear stark h-alpha broadening somewhat incorrectly, but this change fixes the wings. 