### PR TITLE
Fix radiation broadening

### DIFF
--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -309,8 +309,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (
-            linelist["rad"]
+        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
+            4 * np.pi
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -114,9 +114,11 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     Calculates the Voigt profile, the convolution of a Lorentz profile
     and a Gaussian profile.
 
-    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf page 59, eqs 3.63, 3.71, and 3.72).
-    Without the 1/2pi factor, the scipy voigt profile is returned.
+    See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
+    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
+    https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see page 59, 3.71, and 3.72).
+    Without the 1/2pi factor in gamma, the scipy voigt profile is returned.
     There's a factor of 2 unaccounted for, but it's not clear where it comes from.
 
     Parameters

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,7 +48,9 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
+        1j
+        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
+        / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,7 +48,9 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
+        1j
+        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
+        / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -119,7 +121,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
     With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
     the scipy voigt profile is returned. I think this comes from the disagreements in the definition
-    of the voigt profile, (see page 59, 3.68, and 3.71).
+    of the voigt profile, (see page 59, 3.68, and 3.71 versus https://en.wikipedia.org/wiki/Voigt_profile).
 
 
     Parameters

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,9 +48,7 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j
-        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
-        / (0.75 + z**2 * (z**2 - 3.0))
+        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -119,9 +117,10 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see page 59, 3.71, and 3.72).
-    Without the 1/2pi factor in gamma, the scipy voigt profile is returned.
-    There's a factor of 2 unaccounted for, but it's not clear where it comes from.
+    With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
+    the scipy voigt profile is returned. I think this comes from the disagreements in the definition
+    of the voigt profile, (see page 59, 3.68, and 3.71).
+
 
     Parameters
     ----------
@@ -144,7 +143,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
         float(gamma),
     )
 
-    z = complex(delta_nu, gamma / (2 * PI)) / (doppler_width)
+    z = complex(delta_nu, gamma / (SQRT_PI * PI)) / (doppler_width)
     phi = _faddeeva(z).real / (SQRT_PI * doppler_width)
     return phi
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -119,7 +119,7 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     See https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf for equations following.
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2) (see eq. 3.63 versus
     https://en.wikipedia.org/wiki/Doppler_broadening with the equation for Gaussian sigma).
-    With the modification to dopple width, and without the 1/pi**1.5 factor in gamma,
+    With the modification to doppler width, and without the 1/pi**1.5 factor in gamma,
     the scipy voigt profile is returned. I think this comes from the disagreements in the definition
     of the voigt profile, (see page 59, 3.68, and 3.71 versus https://en.wikipedia.org/wiki/Voigt_profile).
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -48,9 +48,7 @@ def _faddeeva(z):
 
     # If in Region II
     w = (
-        1j
-        * (z * (z**2 * 1 / SQRT_PI - 1.4104739589))
-        / (0.75 + z**2 * (z**2 - 3.0))
+        1j * (z * (z**2 * 1 / SQRT_PI - 1.4104739589)) / (0.75 + z**2 * (z**2 - 3.0))
         if IN_REGION_II
         else w
     )
@@ -116,6 +114,10 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     Calculates the Voigt profile, the convolution of a Lorentz profile
     and a Gaussian profile.
 
+    This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi. Without the 1/2pi factor, the scipy voigt profile is returned.
+    There's a factor of 2 unaccounted for, but it's not clear where it comes from.
+
     Parameters
     ----------
     delta_nu : float
@@ -131,9 +133,13 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     phi : float
         Value of Voigt profile.
     """
-    delta_nu, doppler_width, gamma = float(delta_nu), float(doppler_width), float(gamma)
+    delta_nu, doppler_width, gamma = (
+        float(delta_nu),
+        float(doppler_width),
+        float(gamma),
+    )
 
-    z = complex(delta_nu, gamma / (4 * PI)) / doppler_width
+    z = complex(delta_nu, gamma / (2 * PI)) / (doppler_width)
     phi = _faddeeva(z).real / (SQRT_PI * doppler_width)
     return phi
 

--- a/stardis/radiation_field/opacities/opacities_solvers/voigt.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/voigt.py
@@ -115,7 +115,8 @@ def _voigt_profile(delta_nu, doppler_width, gamma):
     and a Gaussian profile.
 
     This disagrees with scipy's voigt profile because doppler width disagrees with a Gaussian sigma by a factor of sqrt(2).
-    Similarly, the dispersion of the Lorentz profile is gamma/4pi. Without the 1/2pi factor, the scipy voigt profile is returned.
+    Similarly, the dispersion of the Lorentz profile is gamma/4pi (see https://robrutten.nl/rrweb/rjr-pubs/2003rtsa.book.....R.pdf page 59, eqs 3.63, 3.71, and 3.72).
+    Without the 1/2pi factor, the scipy voigt profile is returned.
     There's a factor of 2 unaccounted for, but it's not clear where it comes from.
 
     Parameters


### PR DESCRIPTION
Tiny PR to fix radiation broadening factor that was incorrect. Should now correctly parse the radiation broadening from the linelist. 