### PR TITLE
update installation instructions and small changes in physics_of_stardis

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,15 +14,16 @@ Setting Up the Environment
    * STARDIS packages and dependencies are distributed only through the `conda <https://docs.conda.io/en/latest/>`__ package management system, therefore installation requires a conda distribution to be installed on your system. STARDIS uses `Miniconda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__ or `Mamba <https://mamba.readthedocs.io/en/latest/installation.html>`__ by default. Other distributions are untested.
 
 STARDIS uses exclusively the packages in the TARDIS enviroment, as well
-as using the TARDIS code itself. However, since STARDIS can be sensitive
-to changes in TARDIS, we strongly suggest that users create a separate
-environment for STARDIS that pins the TARDIS version. To do this, run
+as using the TARDIS code itself. It uses a shared environment with TARDIS, 
+as well as the TARDIS code itself. We strongly suggest that users create a separate
+environment for STARDIS. To do this, run
 the following in the terminal (replacing ``{platform}`` with
 ``linux-64``, ``linux-64-cuda``, or ``osx-64`` as applicable). 
 
 .. code-block:: bash
 
    $ cd <path-to-stardis-directory>
+   $ wget -q https://raw.githubusercontent.com/tardis-sn/tardis/master/conda-{platform}.lock
    $ conda create --name stardis --file conda-{platform}.lock
    $ conda activate stardis
    $ pip install git+https://github.com/tardis-sn/tardis.git
@@ -35,6 +36,7 @@ If you are using Mamba, the steps are similar:
 .. code-block:: bash
 
    $ cd <path-to-stardis-directory>
+   $ wget -q https://raw.githubusercontent.com/tardis-sn/tardis/master/conda-{platform}.lock
    $ mamba create --name stardis --file conda-{platform}.lock
    $ mamba activate stardis
    $ pip install git+https://github.com/tardis-sn/tardis.git

--- a/docs/physics/physics_of_stardis.rst
+++ b/docs/physics/physics_of_stardis.rst
@@ -6,7 +6,7 @@ Physics of STARDIS
 Model and Plasma
 ================
 
-STARDIS assumes that the stellar atmosphere is spherically symmetric and breaks down the stellar atmosphere into radial depth points, as shown below, and then solves the plasma state at those depth points. We ingest a model atmosphere from a third party such as the MARCS code, a code that generates models of stellar atmospheres, to initialize the temperatures, chemical abundances, and densities at each depth point. The existing TARDIS plasma infrastructure determines the rest of the plasma state, namely the excitation and ionization properties and transition rates of the plasma.
+STARDIS assumes that the stellar atmosphere is spherically symmetric. It solves the state of the plasma at specific depth points throughout the atmosphere, as shown below, before moving light through the plasma. STARDIS ingests a model atmosphere from a third party such as the MARCS code, a code that generates models of stellar atmospheres, to initialize the temperatures, chemical abundances, and densities at each depth point. The code then determines the rest of the plasma, namely the states of the chemicals that compose the plasma, and uses that to understand how the plasma interacts with light.
 
 .. image:: media/model_and_plasma-1.png
    :width: 500 px

--- a/docs/physics/physics_of_stardis.rst
+++ b/docs/physics/physics_of_stardis.rst
@@ -6,7 +6,7 @@ Physics of STARDIS
 Model and Plasma
 ================
 
-STARDIS breaks down the stellar atmosphere into spherically symmetric depth points as shown below and approximates that the plasma state is uniform at each radius or depth point. We ingest a model atmosphere from a third party such as the MARCS code, a code that generates models of stellar atmospheres, to initialize the temperatures, chemical abundances, and densities at each depth point. The existing TARDIS plasma infrastructure determines the rest of the plasma state, namely the excitation and ionization properties and transition rates of the plasma.
+STARDIS assumes that the stellar atmosphere is spherically symmetric and breaks down the stellar atmosphere into radial depth points, as shown below, and then solves the plasma state at those depth points. We ingest a model atmosphere from a third party such as the MARCS code, a code that generates models of stellar atmospheres, to initialize the temperatures, chemical abundances, and densities at each depth point. The existing TARDIS plasma infrastructure determines the rest of the plasma state, namely the excitation and ionization properties and transition rates of the plasma.
 
 .. image:: media/model_and_plasma-1.png
    :width: 500 px

--- a/docs/physics/physics_of_stardis.rst
+++ b/docs/physics/physics_of_stardis.rst
@@ -6,7 +6,7 @@ Physics of STARDIS
 Model and Plasma
 ================
 
-STARDIS breaks down the stellar atmosphere into spherical shells as shown below and approximates that the plasma state is uniform throughout each shell. We rely on the MARCS code, a code that generates models of stellar atmospheres, to determine the temperatures, elemental abundances, and densities in each shell. The existing TARDIS plasma infrastructure determines the rest of the plasma state, namely the excitation and ionization properties and transition rates.
+STARDIS breaks down the stellar atmosphere into spherically symmetric depth points as shown below and approximates that the plasma state is uniform at each radius or depth point. We ingest a model atmosphere from a third party such as the MARCS code, a code that generates models of stellar atmospheres, to initialize the temperatures, chemical abundances, and densities at each depth point. The existing TARDIS plasma infrastructure determines the rest of the plasma state, namely the excitation and ionization properties and transition rates of the plasma.
 
 .. image:: media/model_and_plasma-1.png
    :width: 500 px
@@ -22,7 +22,7 @@ To determine an output spectrum, we need to understand how photons of light move
 Opacity Sources
 ---------------
 
-The first four of these interactions are called continuum interactions, as they affect light at a large range of frequencies. Line interactions, on the other hand, only occur with light around specific frequencies, corresponding to the electron’s jump in energy. These are called *resonant frequencies*.
+The first four of these interactions are called continuum interactions, as they affect light at a large range of frequencies. Line interactions, on the other hand, only occur with light around specific frequencies, corresponding to difference in potential energy of an electron before and after it transitions between states. These are called *resonant frequencies*.
 
 ^^^^^^^^^^^^^^^^^^^^^
 Bound-Free Absorbtion

--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "from stardis.base import run_stardis\n",
     "\n",
-    "from astropy import units as u, constants as const"
+    "from astropy import units as u"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "source": [
     "STARDIS uses [YAML](https://yaml.org/) files for the configuration. The configuration file called `stardis_example.yml` used here can be found\n",
     "[here](https://github.com/tardis-sn/stardis/tree/main/docs/quickstart),\n",
-    "along with any other files from this Quickstart. Below, we present an\n",
+    "along with the other files used in this Quickstart notebook. Below, we present an\n",
     "example for instructions for customizing the configuration for your\n",
     "needs.\n",
     "\n",
@@ -102,7 +102,7 @@
     "atom_data: <filepath to atomic data file>\n",
     "model:\n",
     "    type: marcs # more options will be available in the future\n",
-    "    fname: <filepath to MARCS model file>\n",
+    "    fname: <filepath to model file>\n",
     "    final_atomic_number: <atomic number of largest element considered> # may be up to 30\n",
     "opacity:\n",
     "    file: # reads a bound-free or free-free opacity file, omit if none\n",
@@ -259,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The installation instructions didn't actually work because they ask you to make an environment from a lock file, but they don't tell you how to get that lock file. They also mentioned a pinned TARDIS version, which we moved away from. This fixes those issues. 