### PR TITLE
remove broadening bounds from the config

### DIFF
--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -122,8 +122,6 @@
     "    line: # settings for line interaction opacity, at least one subfield is required\n",
     "        disable: <True or False>\n",
     "        broadening: <list of non-thermal broadening sources considered> # may include radiation, linear_stark, quadratic_stark, and/or van_der_waals, omit or use [] for none\n",
-    "        min: <minimum resonance frequency or wavelength of lines considered> # must have units, such as Hz or AA\n",
-    "        max: <maximum resonance frequency or wavelength of lines considered> # must have units, such as Hz or AA\n",
     "        broadening_range: <maximum distance in frquency space to the resonant frequency for line broadening to be considered> # necessary for computational efficiency and must have units, 1e13 Hz recommended\n",
     "no_of_thetas: <number of angles to sample for raytracing>\n",
     "```\n",
@@ -259,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.11.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/quickstart/stardis_example.yml
+++ b/docs/quickstart/stardis_example.yml
@@ -15,6 +15,4 @@ opacity:
     line:
         disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
-        min: 6500 AA
-        max: 6600 AA
 no_of_thetas: 20

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -110,12 +110,6 @@ properties:
                             - radiation
                         default: []
                         description: Types of broadening to include.
-                    min:
-                        type: quantity
-                        default: 0 Hz
-                    max:
-                        type: quantity
-                        default: inf Hz
                     broadening_range:
                         type: [quantity, "null"]
                         default: null

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -356,10 +356,6 @@ def calc_alpha_line_at_nu(
     if line_opacity_config.disable:
         return 0, 0, 0
 
-    _nu_min = line_opacity_config.min.to(u.Hz, u.spectral())
-    _nu_max = line_opacity_config.max.to(u.Hz, u.spectral())
-    line_nu_min = min(_nu_min, _nu_max)
-    line_nu_max = max(_nu_min, _nu_max)
     line_range = line_opacity_config.broadening_range
 
     use_vald = line_opacity_config.vald_linelist.use_linelist
@@ -394,7 +390,7 @@ def calc_alpha_line_at_nu(
 
     lines_sorted = lines.sort_values("nu")
     lines_sorted_in_range = lines_sorted[
-        lines_sorted.nu.between(line_nu_min, line_nu_max)
+        lines_sorted.nu.between(tracing_nus.min(), tracing_nus.max())
     ]
     line_nus = lines_sorted_in_range.nu.to_numpy()
 
@@ -404,7 +400,7 @@ def calc_alpha_line_at_nu(
         alphas_and_nu = stellar_plasma.alpha_line.sort_values("nu")
 
     alphas_array = (
-        alphas_and_nu[alphas_and_nu.nu.between(line_nu_min, line_nu_max)]
+        alphas_and_nu[alphas_and_nu.nu.between(tracing_nus.min(), tracing_nus.max())]
         .drop(labels="nu", axis=1)
         .to_numpy()
     )

--- a/stardis/tests/stardis_test_config.yml
+++ b/stardis/tests/stardis_test_config.yml
@@ -13,6 +13,4 @@ opacity:
     line:
         disable: False
         broadening: []
-        min: 6560 AA
-        max: 6570 AA
 no_of_thetas: 1

--- a/stardis/tests/stardis_test_config_broadening.yml
+++ b/stardis/tests/stardis_test_config_broadening.yml
@@ -17,8 +17,6 @@ opacity:
     line:
         disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
-        min: 6560 AA
-        max: 6570 AA
         vald_linelist: 
             use_linelist: False
             shortlist: False

--- a/stardis/tests/stardis_test_config_parallel.yml
+++ b/stardis/tests/stardis_test_config_parallel.yml
@@ -18,8 +18,6 @@ opacity:
     line:
         disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
-        min: 6560 AA
-        max: 6570 AA
         vald_linelist: 
             use_linelist: False
             shortlist: False


### PR DESCRIPTION
The wavelength bounds specified in the config were redundant. We already specified bounds of the simulation, and in practice, people would truncate their linelists at the same places as the bounds of their simulation. This change makes the linelist truncation at the same place as the wavelength bounds of the simulation so that you don't have to specify it in the config anymore. 