### PR TITLE
handle case of strings in config update

### DIFF
--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -55,8 +55,6 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
             config.set_config_item(add_config_keys, add_config_vals)
         else:
             # Proceed with iteration if add_config_keys is not a string
-            for key, val in zip(add_config_keys, add_config_vals):
-                config.set_config_item(key, val)
             try:
                 for key, val in zip(add_config_keys, add_config_vals):
                     config.set_config_item(key, val)

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -50,11 +50,18 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
         pass
     else:
         print("Updating config with additional keys and values")
-        try:
+        if isinstance(add_config_keys, str):
+            # Directly set the config item if add_config_keys is a string
+            config.set_config_item(add_config_keys, add_config_vals)
+        else:
+            # Proceed with iteration if add_config_keys is not a string
             for key, val in zip(add_config_keys, add_config_vals):
                 config.set_config_item(key, val)
-        except:
-            config.set_config_item(add_config_keys, add_config_vals)
+            try:
+                for key, val in zip(add_config_keys, add_config_vals):
+                    config.set_config_item(key, val)
+            except:
+                config.set_config_item(add_config_keys, add_config_vals)
 
         try:
             config_dict = validate_dict(config, schemapath=SCHEMA_PATH)

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -55,11 +55,17 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
             config.set_config_item(add_config_keys, add_config_vals)
         else:
             # Proceed with iteration if add_config_keys is not a string
+            if len(add_config_keys) != len(add_config_vals):
+                raise ValueError(
+                    "Length of additional config keys and values do not match."
+                )
             try:
                 for key, val in zip(add_config_keys, add_config_vals):
                     config.set_config_item(key, val)
             except:
-                config.set_config_item(add_config_keys, add_config_vals)
+                raise ValueError(
+                    f"{add_config_keys} not a valid type. Should be a single string or a list of strings for keys."
+                )
 
         try:
             config_dict = validate_dict(config, schemapath=SCHEMA_PATH)


### PR DESCRIPTION
The previous code would fail if a string was provided because it attempts to iterate through the keys provide which works if the keys provided are a list. This fails because it attempts to iterate through the string (setting each character as an item in the config). This catches the case of a string being passed. 