### PR TITLE
fix benchmarks config

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,7 @@
 name: benchmarks
 
 env:
-  TARDIS_VER: master # release-2023.06.18
+  TARDIS_VER: master 
 
 on:
   push:
@@ -74,7 +74,7 @@ jobs:
 
       - name: Download TARDIS dependencies
         run: |
-          LOCK_URL="https://github.com/tardis-sn/tardis/raw/${{ env.TARDIS_VER }}/tardis_env3.yml"
+          LOCK_URL="https://github.com/tardis-sn/tardis/raw/${{ env.TARDIS_VER }}/conda-linux64.lock"
           wget -q "$LOCK_URL"
 
       - name: Add TARDIS install command to asv config file

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Download TARDIS dependencies
         run: |
-          LOCK_URL="https://github.com/tardis-sn/tardis/raw/${{ env.TARDIS_VER }}/conda-linux64.lock"
+          LOCK_URL="https://github.com/tardis-sn/tardis/raw/${{ env.TARDIS_VER }}/tardis_env3.yml"
           wget -q "$LOCK_URL"
 
       - name: Add TARDIS install command to asv config file

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,17 +1,22 @@
-
 {
     "version": 1,
     "project": "stardis",
     "project_url": "https://tardis-sn.github.io/tardis",
     "repo": ".",
-    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    "install_command": [
+        "in-dir={env_dir} python -mpip install {wheel_file}"
+    ],
+    "uninstall_command": [
+        "return-code=any python -mpip uninstall -y {project}"
+    ],
     "build_command": [
         "python setup.py build",
         "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
-    "branches": ["main"],
-    "environment_type": "conda",
+    "branches": [
+        "main"
+    ],
+    "environment_type": "mamba",
     "show_commit_url": "https://github.com/tardis-sn/stardis/commit",
     "conda_environment_file": "tardis_env3.yml",
     "benchmark_dir": "benchmarks",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
     "branches": [
         "main"
     ],
-    "environment_type": "mamba",
+    "environment_type": "conda",
     "show_commit_url": "https://github.com/tardis-sn/stardis/commit",
     "conda_environment_file": "tardis_env3.yml",
     "benchmark_dir": "benchmarks",

--- a/benchmarks/benchmark_config.yml
+++ b/benchmarks/benchmark_config.yml
@@ -15,7 +15,5 @@ opacity:
     line:
         disable: False
         broadening: [radiation, linear_stark, quadratic_stark, van_der_waals]
-        min: 6500 AA
-        max: 6600 AA
         broadening_range: 3 AA
 no_of_thetas: 20


### PR DESCRIPTION
I broke the benchmarks again because the config file it wants use the now removed broadening max and min. 

This also cleans up the asv workflow a little. 