### PR TITLE
Running stardis test with tardis push commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         id: install-tardis
         # shell: bash -l {0}
         run: |
-          pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.sha }}
+          pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.commit_sha }}
           
       - name: Install STARDIS
         id: install-stardis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: tests
 
 on:
   push:
+  repository_dispatch:
+    types: [trigger-workflow]
   pull_request:
   workflow_dispatch:
 
@@ -65,7 +67,7 @@ jobs:
         id: install-tardis
         # shell: bash -l {0}
         run: |
-          pip install git+https://github.com/tardis-sn/tardis.git
+          pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.sha }}
           
       - name: Install STARDIS
         id: install-stardis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         # shell: bash -l {0}
         run: |
           pip install git+https://github.com/tardis-sn/tardis.git
-
+          
       - name: Install STARDIS
         id: install-stardis
         # shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
   repository_dispatch:
-    types: [Tardis-Dispatch]
+    types: [tardis-dispatch]
   pull_request:
   workflow_dispatch:
 
@@ -67,13 +67,7 @@ jobs:
         id: install-tardis
         # shell: bash -l {0}
         run: |
-            if [ "${{ github.event.action }}" == "Tardis-Dispatch" ]; then
-              echo "Triggered by repository dispatch, installing the latest version of TARDIS."
-              pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.commit_sha }}
-            else
-              echo "Not triggered by repository dispatch, installing the latest version of TARDIS."
-              pip install git+https://github.com/${{ github.repository_owner }}/tardis.git
-            fi
+          pip install git+https://github.com/tardis-sn/tardis.git
 
       - name: Install STARDIS
         id: install-stardis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
   repository_dispatch:
-    types: [trigger-workflow]
+    types: [Tardis-Dispatch]
   pull_request:
   workflow_dispatch:
 
@@ -67,8 +67,14 @@ jobs:
         id: install-tardis
         # shell: bash -l {0}
         run: |
-          pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.commit_sha }}
-          
+            if [ "${{ github.event.action }}" == "Tardis-Dispatch" ]; then
+              echo "Triggered by repository dispatch, installing the latest version of TARDIS."
+              pip install git+https://github.com/${{github.repository_owner}}/tardis.git@${{ github.event.client_payload.commit_sha }}
+            else
+              echo "Not triggered by repository dispatch, installing the latest version of TARDIS."
+              pip install git+https://github.com/${{ github.repository_owner }}/tardis.git
+            fi
+
       - name: Install STARDIS
         id: install-stardis
         # shell: bash -l {0}


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The PR aims to run stardis tests after every commit on the tardis master branch. It is related to [#2708](https://github.com/tardis-sn/tardis/pull/2708) in tardis.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
