### PR TITLE
use np interpolator instead of scipy

### DIFF
--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -3,7 +3,6 @@ import pandas as pd
 import logging
 
 from astropy import constants as const, units as u
-from scipy.interpolate import interp1d
 
 from tardis.plasma.base import BasePlasma
 from tardis.plasma.properties.base import (
@@ -118,11 +117,13 @@ class H2PlusDensity(ProcessingPlasmaProperty):
     outputs = ("h2_plus_density",)
 
     def calculate(self, ion_number_density, t_rad):
-        interp_Ks = interp1d(H2_PLUS_K_SAMPLE_TEMPS, H2_PLUS_K_EQUILIBRIUM_CONSTANT)
         h_neutral_density = ion_number_density.loc[1, 0]
         h_plus_density = ion_number_density.loc[1, 1]
+        resampled_Ks = np.interp(
+            t_rad, H2_PLUS_K_SAMPLE_TEMPS, H2_PLUS_K_EQUILIBRIUM_CONSTANT
+        )
         return (
-            h_neutral_density * h_plus_density / interp_Ks(t_rad) * 1e-19
+            h_neutral_density * h_plus_density / resampled_Ks * 1e-19
         )  # scale factor from Stancil 1994 table 1
 
 

--- a/stardis/radiation_field/opacities/opacities_solvers/util.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/util.py
@@ -4,7 +4,7 @@ import pandas as pd
 from astropy import units as u, constants as const
 from tardis.util.base import species_string_to_tuple
 
-from scipy.interpolate import interp1d, LinearNDInterpolator
+from scipy.interpolate import LinearNDInterpolator
 
 
 def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
@@ -83,16 +83,11 @@ def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
         h_minus_bf_table = pd.read_csv(
             fpath, header=None, comment="#", names=["wavelength", "cross_section"]
         )
-        linear_interp_1d_from_file = interp1d(
+        sigmas = np.interp(
+            tracing_lambdas,
             h_minus_bf_table.wavelength.values,
             h_minus_bf_table.cross_section.values,
-            bounds_error=False,
-            fill_value=(
-                h_minus_bf_table.cross_section.iloc[0],
-                h_minus_bf_table.cross_section.iloc[-1],
-            ),
         )
-        sigmas = linear_interp_1d_from_file(tracing_lambdas)
 
     else:
         raise ValueError(f"Unknown opacity_source: {opacity_source}")


### PR DESCRIPTION
Scipy's linear1d interpolator is deprecated, so we're using numpy's instead. This also has the benefit of fixing an out of bounds error that sometimes came up to use the behavior we want of fill values being the first and last entry. 