### PR TITLE
Make h2bf opacity 0 outside of bounds

### DIFF
--- a/benchmarks/run_stardis.py
+++ b/benchmarks/run_stardis.py
@@ -98,7 +98,6 @@ class Sim10AA:
         raytrace(
             self.stellar_model,
             self.stellar_radiation_field,
-            no_of_thetas=self.config.no_of_thetas,
         )
 
     def time_calc_alpha_line_at_nu(self):
@@ -209,7 +208,6 @@ class Sim100AA:
         raytrace(
             self.stellar_model,
             self.stellar_radiation_field,
-            no_of_thetas=self.config.no_of_thetas,
         )
 
     def time_calc_alpha_line_at_nu(self):

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -26,10 +26,6 @@ properties:
                 type: boolean
                 default: false
                 description: Whether the file is gzipped. Only used for marcs models.            
-            spherical:
-                type: boolean
-                default: false
-                description: Whether the model is spherical. Only used for marcs models.
             final_atomic_number:
                 type: number
                 multipleOf: 1

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -26,6 +26,10 @@ properties:
                 type: boolean
                 default: false
                 description: Whether the file is gzipped. Only used for marcs models.            
+            spherical:
+                type: boolean
+                default: false
+                description: Whether the model is spherical. Only used for marcs models.
             final_atomic_number:
                 type: number
                 multipleOf: 1

--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -190,7 +190,7 @@ def example_stellar_radiation_field(
     example_stellar_model, example_config, example_tracing_nus, example_stellar_plasma
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model
+        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config.no_of_thetas
     )
 
     calc_alphas(
@@ -216,7 +216,7 @@ def example_stellar_radiation_field_broadening(
     example_stellar_plasma_broadening,
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model
+        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config_broadening.no_of_thetas
     )
 
     calc_alphas(
@@ -242,7 +242,7 @@ def example_stellar_radiation_field_parallel(
     example_stellar_plasma_broadening,
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model
+        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config_parallel.no_of_thetas
     )
 
     calc_alphas(

--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -203,7 +203,6 @@ def example_stellar_radiation_field(
     raytrace(
         example_stellar_model,
         stellar_radiation_field,
-        no_of_thetas=example_config.no_of_thetas,
     )
     return stellar_radiation_field
 
@@ -229,7 +228,6 @@ def example_stellar_radiation_field_broadening(
     raytrace(
         example_stellar_model,
         stellar_radiation_field,
-        no_of_thetas=example_config_broadening.no_of_thetas,
     )
     return stellar_radiation_field
 
@@ -256,7 +254,6 @@ def example_stellar_radiation_field_parallel(
     raytrace(
         example_stellar_model,
         stellar_radiation_field,
-        no_of_thetas=example_config_parallel.no_of_thetas,
         n_threads=example_config_parallel.n_threads,
     )
     return stellar_radiation_field

--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -190,7 +190,10 @@ def example_stellar_radiation_field(
     example_stellar_model, example_config, example_tracing_nus, example_stellar_plasma
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config.no_of_thetas
+        example_tracing_nus,
+        blackbody_flux_at_nu,
+        example_stellar_model,
+        example_config.no_of_thetas,
     )
 
     calc_alphas(
@@ -215,7 +218,10 @@ def example_stellar_radiation_field_broadening(
     example_stellar_plasma_broadening,
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config_broadening.no_of_thetas
+        example_tracing_nus,
+        blackbody_flux_at_nu,
+        example_stellar_model,
+        example_config_broadening.no_of_thetas,
     )
 
     calc_alphas(
@@ -240,7 +246,10 @@ def example_stellar_radiation_field_parallel(
     example_stellar_plasma_broadening,
 ):
     stellar_radiation_field = RadiationField(
-        example_tracing_nus, blackbody_flux_at_nu, example_stellar_model, example_config_parallel.no_of_thetas
+        example_tracing_nus,
+        blackbody_flux_at_nu,
+        example_stellar_model,
+        example_config_parallel.no_of_thetas,
     )
 
     calc_alphas(

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -80,7 +80,7 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
     logger.info("Reading model")
     if config.model.type == "marcs":
         raw_marcs_model = read_marcs_model(
-            Path(config.model.fname), gzipped=config.model.gzipped
+            Path(config.model.fname), gzipped=config.model.gzipped, spherical=config.model.spherical
         )
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -80,7 +80,9 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
     logger.info("Reading model")
     if config.model.type == "marcs":
         raw_marcs_model = read_marcs_model(
-            Path(config.model.fname), gzipped=config.model.gzipped, spherical=config.model.spherical
+            Path(config.model.fname),
+            gzipped=config.model.gzipped,
+            spherical=config.model.spherical,
         )
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -82,7 +82,6 @@ def parse_config_to_model(config_fname, add_config_keys=None, add_config_vals=No
         raw_marcs_model = read_marcs_model(
             Path(config.model.fname),
             gzipped=config.model.gzipped,
-            spherical=config.model.spherical,
         )
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -163,6 +163,8 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
             Path to model file
     gzipped : Bool
             Whether or not the file is gzipped
+    spherical : Bool
+            Whether or not the model is spherical
 
     Returns
     -------
@@ -387,6 +389,8 @@ def read_marcs_model(fpath, gzipped=True, spherical=False):
             Path to model file
     gzipped : Bool
             Whether or not the file is gzipped
+    spherical : Bool
+            Whether or not the model is spherical
 
     Returns
     -------

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -32,13 +32,15 @@ class MARCSModel(object):
         -------
         stardis.model.geometry.radial1d.Radial1DGeometry
         """
+
+        reference_r = None
         r = (
             -self.data.depth.values[::-1] * u.cm
         )  # Flip data to move from innermost stellar point to surface
         if self.spherical:
             r += self.metadata["radius"]
-
-        return Radial1DGeometry(r)
+            reference_r = self.metadata["radius"]
+        return Radial1DGeometry(r, reference_r)
 
     def to_composition(self, atom_data, final_atomic_number):
         """

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -22,6 +22,7 @@ class MARCSModel(object):
 
     metadata: dict
     data: pd.DataFrame
+    spherical: bool
 
     def to_geometry(self):
         """
@@ -34,6 +35,9 @@ class MARCSModel(object):
         r = (
             -self.data.depth.values[::-1] * u.cm
         )  # Flip data to move from innermost stellar point to surface
+        if self.spherical:
+            r += self.metadata['radius'] 
+            
         return Radial1DGeometry(r)
 
     def to_composition(self, atom_data, final_atomic_number):
@@ -264,7 +268,6 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
 
     # Compile each of the regex pattern strings then open the file and match each of the patterns by line.
     # Then add each of the matched patterns as a key:value pair to the metadata dict.
-    spherical = True
     if spherical:
         metadata_re = [re.compile(re_str[0]) for re_str in METADATA_SPHERICAL_RE_STR]
         metadata_re_str = METADATA_SPHERICAL_RE_STR
@@ -375,7 +378,7 @@ def read_marcs_data(fpath, gzipped=True):
     return marcs_model_data
 
 
-def read_marcs_model(fpath, gzipped=True):
+def read_marcs_model(fpath, gzipped=True, spherical=False):
     """
     Parameters
     ----------
@@ -389,7 +392,7 @@ def read_marcs_model(fpath, gzipped=True):
     model : MARCSModel
         Assembled metadata and data pair of a MARCS model
     """
-    metadata = read_marcs_metadata(fpath, gzipped=gzipped)
+    metadata = read_marcs_metadata(fpath, gzipped=gzipped, spherical=spherical)
     data = read_marcs_data(fpath, gzipped=gzipped)
 
-    return MARCSModel(metadata, data)
+    return MARCSModel(metadata, data, spherical=spherical)

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -403,7 +403,12 @@ def read_marcs_model(fpath, gzipped=True, spherical=False):
     model : MARCSModel
         Assembled metadata and data pair of a MARCS model
     """
-    metadata = read_marcs_metadata(fpath, gzipped=gzipped, spherical=spherical)
+    try:
+        metadata = read_marcs_metadata(fpath, gzipped=gzipped, spherical=spherical)
+    except:
+        raise ValueError(
+            "Failed to read metadata from MARCS model file. Make sure that you are specifying if the file is gzipped, and whether the model is spherical or plane-parallel appropriately."
+        )
     data = read_marcs_data(fpath, gzipped=gzipped)
 
     return MARCSModel(metadata, data, spherical=spherical)

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -36,8 +36,8 @@ class MARCSModel(object):
             -self.data.depth.values[::-1] * u.cm
         )  # Flip data to move from innermost stellar point to surface
         if self.spherical:
-            r += self.metadata['radius'] 
-            
+            r += self.metadata["radius"]
+
         return Radial1DGeometry(r)
 
     def to_composition(self, atom_data, final_atomic_number):
@@ -250,7 +250,11 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
             "radius",
             "radius_units",
         ),
-        (r"\s+(\d+\.\d+(?:E[+-]?\d+)?) Luminosity \[(.+)\]", "luminosity", "luminosity_units"),
+        (
+            r"\s+(\d+\.\d+(?:E[+-]?\d+)?) Luminosity \[(.+)\]",
+            "luminosity",
+            "luminosity_units",
+        ),
         (
             r"  (\d+.\d+) (\d+.\d+) (\d+.\d+) (\d+.\d+) are the convection parameters: alpha, nu, y and beta",
             "conv_alpha",
@@ -290,8 +294,8 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
             contents = file.readlines(BYTES_THROUGH_METADATA)
 
     lines = list(contents)
-    
-    #Check each line against the regex patterns and add the matched values to the metadata dictionary
+
+    # Check each line against the regex patterns and add the matched values to the metadata dictionary
     for i in range(len(metadata_re_str)):
         line = lines[i]
         metadata_re_match = metadata_re[i].match(line)

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -416,7 +416,7 @@ def read_marcs_model(fpath, gzipped=True):
         metadata, spherical = read_marcs_metadata(fpath, gzipped=gzipped)
     except:
         raise ValueError(
-            "Failed to read metadata from MARCS model file. Make sure that you are specifying if the file is gzipped, and whether the model is spherical or plane-parallel appropriately."
+            "Failed to read metadata from MARCS model file. Make sure that you are specifying if the file is gzipped appropriately."
         )
     data = read_marcs_data(fpath, gzipped=gzipped)
 

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -268,6 +268,7 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
 
     # Compile each of the regex pattern strings then open the file and match each of the patterns by line.
     # Then add each of the matched patterns as a key:value pair to the metadata dict.
+    # Files are formatted a little differently depending on if the MARCS model is spherical or plane-parallel
     if spherical:
         metadata_re = [re.compile(re_str[0]) for re_str in METADATA_SPHERICAL_RE_STR]
         metadata_re_str = METADATA_SPHERICAL_RE_STR
@@ -288,10 +289,10 @@ def read_marcs_metadata(fpath, gzipped=True, spherical=False):
 
     lines = list(contents)
     
+    #Check each line against the regex patterns and add the matched values to the metadata dictionary
     for i in range(len(metadata_re_str)):
         line = lines[i]
         metadata_re_match = metadata_re[i].match(line)
-
         for j, metadata_name in enumerate(metadata_re_str[i][1:]):
             metadata[metadata_name] = metadata_re_match.group(j + 1)
 

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -147,7 +147,7 @@ class MARCSModel(object):
         return StellarModel(temperatures, marcs_geometry, marcs_composition)
 
 
-def read_marcs_metadata(fpath, gzipped=True):
+def read_marcs_metadata(fpath, gzipped=True, spherical=False):
     """
     Grabs the metadata information from a gzipped MARCS model file and returns it in a python dictionary.
     Matches the metadata information and units using regex. Assumes file line structure of plane-parallel models.
@@ -210,6 +210,11 @@ def read_marcs_metadata(fpath, gzipped=True):
             "12C/13C",
         ),
     ]
+    
+    if spherical:
+        #append regex string to grab the reference radius of the model
+        #this should be added to the depth points to get the actual radius of the model when the geometry object is created
+        pass
     BYTES_THROUGH_METADATA = 550
 
     # Compile each of the regex pattern strings then open the file and match each of the patterns by line.

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -21,14 +21,17 @@ class StellarModel(HDFWriterMixin):
         Composition of the model. Includes density and atomic mass fractions.
     no_of_depth_points : int
         Class attribute to be easily accessible for initializing arrays that need to match the shape of the model.
+    spherical : bool
+        Flag for spherical geometry.
     """
 
     hdf_properties = ["temperatures", "geometry", "composition"]
 
-    def __init__(self, temperatures, geometry, composition):
+    def __init__(self, temperatures, geometry, composition, spherical=False):
         self.temperatures = temperatures
         self.geometry = geometry
         self.composition = composition
+        self.spherical = spherical
 
     @property
     def no_of_depth_points(self):

--- a/stardis/model/geometry/radial1d.py
+++ b/stardis/model/geometry/radial1d.py
@@ -14,8 +14,9 @@ class Radial1DGeometry:
         distance to the next depth point
     """
 
-    def __init__(self, r):
+    def __init__(self, r, reference_r=None):
         self.r = r
+        self.reference_r = reference_r
 
     @property
     def dist_to_next_depth_point(self):

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -48,17 +48,19 @@ class RadiationField(HDFWriterMixin):
         self.opacities = Opacities(frequencies, stellar_model)
         self.F_nu = np.zeros((stellar_model.no_of_depth_points, len(frequencies)))
 
-        # thetas, weights = np.polynomial.legendre.leggauss(num_of_thetas) # This block migrates to Gauss-Legendre quadrature
-        # self.thetas = (thetas / 2) + 0.5 * np.pi / 2
-        # self.I_nus_weights = weights * np.pi / 2
+        # This uses gauss-legendre quadrature to sample thetas
+        thetas, weights = np.polynomial.legendre.leggauss(num_of_thetas)
+        self.thetas = (thetas / 2) + 0.5 * np.pi / 2
+        self.I_nus_weights = weights * np.pi / 2
 
-        dtheta = (np.pi / 2) / num_of_thetas  # Korg uses Gauss-Legendre quadrature here
-        start_theta = dtheta / 2
-        end_theta = (np.pi / 2) - (dtheta / 2)
-        self.thetas = np.linspace(start_theta, end_theta, num_of_thetas)
-        self.I_nus_weights = (
-            2 * np.pi * dtheta * np.sin(self.thetas) * np.cos(self.thetas)
-        )
+        # This was our original theta sampling method
+        # dtheta = (np.pi / 2) / num_of_thetas  # Korg uses Gauss-Legendre quadrature here
+        # start_theta = dtheta / 2
+        # end_theta = (np.pi / 2) - (dtheta / 2)
+        # self.thetas = np.linspace(start_theta, end_theta, num_of_thetas)
+        # self.I_nus_weights = (
+        #     2 * np.pi * dtheta * np.sin(self.thetas) * np.cos(self.thetas)
+        # )
 
         self.I_nus = np.zeros(
             (stellar_model.no_of_depth_points, len(frequencies), len(self.thetas))

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -85,6 +85,7 @@ def create_stellar_radiation_field(tracing_nus, stellar_model, stellar_plasma, c
         stellar_radiation_field,
         no_of_thetas=config.no_of_thetas,
         n_threads=config.n_threads,
+        spherical=config.model.spherical,
     )
 
     return stellar_radiation_field

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -40,17 +40,13 @@ class RadiationField(HDFWriterMixin):
         self.source_function = source_function
         self.opacities = Opacities(frequencies, stellar_model)
         self.F_nu = np.zeros((stellar_model.no_of_depth_points, len(frequencies)))
-        
+
         thetas, weights = np.polynomial.legendre.leggauss(num_of_thetas)
         self.thetas = (thetas / 2) + 0.5 * np.pi / 2
         self.I_nus_weights = weights * np.pi / 2
-
-        # dtheta = (np.pi / 2) / num_of_thetas  # Korg uses Gauss-Legendre quadrature here
-        # start_theta = dtheta / 2
-        # end_theta = (np.pi / 2) - (dtheta / 2)
-        # self.thetas = np.linspace(start_theta, end_theta, num_of_thetas)
-        # self.I_nus_weights = 2 * np.pi * dtheta * np.sin(self.thetas) * np.cos(self.thetas)
-        self.I_nus = np.zeros((stellar_model.no_of_depth_points, len(frequencies), len(self.thetas)))
+        self.I_nus = np.zeros(
+            (stellar_model.no_of_depth_points, len(frequencies), len(self.thetas))
+        )
 
 
 def create_stellar_radiation_field(tracing_nus, stellar_model, stellar_plasma, config):
@@ -94,7 +90,6 @@ def create_stellar_radiation_field(tracing_nus, stellar_model, stellar_plasma, c
     raytrace(
         stellar_model,
         stellar_radiation_field,
-        no_of_thetas=config.no_of_thetas,
         n_threads=config.n_threads,
         spherical=config.model.spherical,
     )

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -107,7 +107,6 @@ def create_stellar_radiation_field(tracing_nus, stellar_model, stellar_plasma, c
         stellar_model,
         stellar_radiation_field,
         n_threads=config.n_threads,
-        spherical=config.model.spherical,
     )
 
     return stellar_radiation_field

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -18,7 +18,8 @@ class RadiationField(HDFWriterMixin):
     ----------
     frequencies : astronopy.units.Quantity
     source_function : stardis.radiation_field.source_function
-    opacities : stardis.radiation_field.opacities
+    stellar_model : stardis.stellar_model.StellarModel
+    num_of_thetas : int
 
     Attributes
     ----------
@@ -31,6 +32,12 @@ class RadiationField(HDFWriterMixin):
         calculate the total opacity at each frequency at each depth point.
     F_nu : numpy.ndarray
         Radiation field fluxes at each frequency at each depth point. Initialized as zeros and calculated by a solver.
+    thetas : numpy.ndarray
+        Theta angles for raytracing.
+    I_nus_weights : numpy.ndarray
+        Weights for the theta angles.
+    I_nus : numpy.ndarray
+        Radiation field intensity at each frequency at each depth point at each theta angle. Initialized as zeros and calculated by a solver.
     """
 
     hdf_properties = ["frequencies", "opacities", "F_nu"]

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -48,9 +48,18 @@ class RadiationField(HDFWriterMixin):
         self.opacities = Opacities(frequencies, stellar_model)
         self.F_nu = np.zeros((stellar_model.no_of_depth_points, len(frequencies)))
 
-        thetas, weights = np.polynomial.legendre.leggauss(num_of_thetas)
-        self.thetas = (thetas / 2) + 0.5 * np.pi / 2
-        self.I_nus_weights = weights * np.pi / 2
+        # thetas, weights = np.polynomial.legendre.leggauss(num_of_thetas) # This block migrates to Gauss-Legendre quadrature
+        # self.thetas = (thetas / 2) + 0.5 * np.pi / 2
+        # self.I_nus_weights = weights * np.pi / 2
+
+        dtheta = (np.pi / 2) / num_of_thetas  # Korg uses Gauss-Legendre quadrature here
+        start_theta = dtheta / 2
+        end_theta = (np.pi / 2) - (dtheta / 2)
+        self.thetas = np.linspace(start_theta, end_theta, num_of_thetas)
+        self.I_nus_weights = (
+            2 * np.pi * dtheta * np.sin(self.thetas) * np.cos(self.thetas)
+        )
+
         self.I_nus = np.zeros(
             (stellar_model.no_of_depth_points, len(frequencies), len(self.thetas))
         )

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -626,12 +626,12 @@ def test_rotational_broadening(example_stardis_output):
     )
 
     expected_broadening_fluxes = [
-        21851984.04113946, 
-        21851937.30115837, 
-        21851843.93664505, 
-        21851704.17866379, 
-        21851518.37423182, 
-        21851286.98683553
+        21851984.04113946,
+        21851937.30115837,
+        21851843.93664505,
+        21851704.17866379,
+        21851518.37423182,
+        21851286.98683553,
     ]
     actual_wavelengths, actual_fluxes = rotation_broadening(
         20 * u.km / u.s,

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -626,12 +626,12 @@ def test_rotational_broadening(example_stardis_output):
     )
 
     expected_broadening_fluxes = [
-        21851984.04113946,
-        21851937.30115837,
-        21851843.93664505,
-        21851704.17866379,
-        21851518.37423182,
-        21851286.98683553,
+        34325016.26500256,
+        34324942.84601195,
+        34324796.18937738,
+        34324576.65805378,
+        34324284.79713453,
+        34323921.33466238,
     ]
     actual_wavelengths, actual_fluxes = rotation_broadening(
         20 * u.km / u.s,

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -626,12 +626,12 @@ def test_rotational_broadening(example_stardis_output):
     )
 
     expected_broadening_fluxes = [
-        34325016.26500256,
-        34324942.84601195,
-        34324796.18937738,
-        34324576.65805378,
-        34324284.79713453,
-        34323921.33466238,
+        21851984.04113946,
+        21851937.30115837,
+        21851843.93664505,
+        21851704.17866379,
+        21851518.37423182,
+        21851286.98683553,
     ]
     actual_wavelengths, actual_fluxes = rotation_broadening(
         20 * u.km / u.s,

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -626,14 +626,12 @@ def test_rotational_broadening(example_stardis_output):
     )
 
     expected_broadening_fluxes = [
-        34325016.26500261,
-        34324942.84601202,
-        34324796.18937743,
-        34324576.65805383,
-        34324284.79713459,
-        34323921.33466243,
-        34323487.18274513,
-        34322983.43899771,
+        21851984.04113946, 
+        21851937.30115837, 
+        21851843.93664505, 
+        21851704.17866379, 
+        21851518.37423182, 
+        21851286.98683553
     ]
     actual_wavelengths, actual_fluxes = rotation_broadening(
         20 * u.km / u.s,
@@ -645,4 +643,4 @@ def test_rotational_broadening(example_stardis_output):
     assert np.allclose(
         actual_fluxes_no_broadening, example_stardis_output.spectrum_lambda
     )
-    assert np.allclose(actual_fluxes[:8].value, expected_broadening_fluxes)
+    assert np.allclose(actual_fluxes[:6].value, expected_broadening_fluxes)

--- a/stardis/radiation_field/opacities/opacities_solvers/util.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/util.py
@@ -69,6 +69,7 @@ def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
         linear_interp_hminus_ff = LinearNDInterpolator(
             np.vstack([file_waves_mesh.ravel(), file_thetas_mesh.ravel()]).T,
             file_values.flatten(),
+            fill_value=0,
         )
         lambdas, thetas = np.meshgrid(tracing_lambdas, 5040 / temperatures)
         sigmas = (

--- a/stardis/radiation_field/opacities/opacities_solvers/util.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/util.py
@@ -46,6 +46,7 @@ def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
         linear_interp_h2plus_bf = LinearNDInterpolator(
             np.vstack([file_waves_mesh.ravel(), file_temps_mesh.ravel()]).T,
             file_cross_sections.flatten(),
+            fill_value=0,
         )
         lambdas, temps = np.meshgrid(tracing_lambdas, temperatures)
         sigmas = (

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -92,7 +92,7 @@ def single_theta_trace_parallel(
     inward_rays=False,
 ):
     """
-    Performs ray tracing at an angle following van Noort 2001 eq 14.
+    Performs ray tracing at an angle following van Noort 2001 eq 14, parallelized over frequencies.
 
     Parameters
     ----------
@@ -281,6 +281,9 @@ def all_thetas_trace(
     """
     Performs ray tracing at an angle following van Noort 2001 eq 14.
 
+    Currently not using this method in favor of the parallelized njit version because it does not work correctly in spherical geometry.
+    This method is kept for reference.
+
     Parameters
     ----------
     geometry_dist_to_next_depth_point : numpy.ndarray
@@ -455,7 +458,7 @@ def calculate_spherical_ray(thetas, depth_points_radii):
         Array of angles in radians.
     depth_points_radii : numpy.ndarray
         Array of radii of each depth point in the star.
-        
+
     Returns
     -------
     ray_distance_through_layer_by_impact_parameter : numpy.ndarray
@@ -465,7 +468,7 @@ def calculate_spherical_ray(thetas, depth_points_radii):
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))
     )
-    
+
     for theta_index, theta in enumerate(thetas):
         b = depth_points_radii[-1] * np.sin(theta)  # impact parameter of the ray
         ray_z_coordinate_grid = np.sqrt(

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -108,7 +108,7 @@ def single_theta_trace_parallel(
         Numpy array of frequencies used for ray tracing with units of Hz.
     inward_rays : bool, optional
         If True, rays are traced from the outermost layer to the innermost layer before the standard tracing
-        from the innermost layer to the outermost layer, by default False. Useful in spherical geometries. 
+        from the innermost layer to the outermost layer, by default False. Useful in spherical geometries.
 
     Returns
     -------
@@ -137,7 +137,7 @@ def single_theta_trace_parallel(
 
     w0, w1, w2 = calc_weights_parallel(taus)
 
-    #In spherical geometry, for outside rays, you need to handle the ray that goes through the star and comes out the other side.
+    # In spherical geometry, for outside rays, you need to handle the ray that goes through the star and comes out the other side.
     if inward_rays:
         for nu_index in numba.prange(len(tracing_nus)):
             for gap_index in (np.arange(no_of_depth_gaps - 1) + 1)[::-1]:
@@ -195,7 +195,7 @@ def single_theta_trace_parallel(
                         + second_term
                         + third_term
                     )
-                #This is wrong, but probably doesn't matter. This is the innermost point of the star for an inward ray. 
+                # This is wrong, but probably doesn't matter. This is the innermost point of the star for an inward ray.
                 I_nu_theta[0, nu_index] = I_nu_theta[1, nu_index]
 
     for nu_index in numba.prange(len(tracing_nus)):
@@ -276,7 +276,7 @@ def all_thetas_trace(
     tracing_nus,
     num_of_thetas,
     source_function,
-    inward_rays=False
+    inward_rays=False,
 ):
     """
     Performs ray tracing at an angle following van Noort 2001 eq 14.
@@ -340,10 +340,10 @@ def all_thetas_trace(
         )
         / (taus[gap_indices] + taus[gap_indices + 1])
     )
-    
+
     if inward_rays:
         pass
-    
+
     for gap_index in range(
         no_of_depth_gaps - 1
     ):  # solve the ray tracing equation out to the surface of the star, not including the last jump
@@ -403,8 +403,10 @@ def raytrace(
             -1, 1
         ) / np.cos(stellar_radiation_field.thetas)
         inward_rays = False
-    if False: #Commenting out serial threaded block for now - currently doesn't work with spherical geometry and not sure it's worth maintaining
-    # if n_threads == 1:  # Single threaded
+    if (
+        False
+    ):  # Commenting out serial threaded block for now - currently doesn't work with spherical geometry and not sure it's worth maintaining
+        # if n_threads == 1:  # Single threaded
         stellar_radiation_field.I_nus = all_thetas_trace(
             ray_distances,
             stellar_model.temperatures.value.reshape(-1, 1),
@@ -412,7 +414,7 @@ def raytrace(
             stellar_radiation_field.frequencies,
             len(stellar_radiation_field.thetas),
             stellar_radiation_field.source_function,
-            inward_rays
+            inward_rays,
         )
         stellar_radiation_field.F_nu = np.sum(
             stellar_radiation_field.I_nus_weights * stellar_radiation_field.I_nus,
@@ -426,7 +428,7 @@ def raytrace(
                 stellar_radiation_field.opacities.total_alphas,
                 stellar_radiation_field.frequencies,
                 stellar_radiation_field.source_function,
-                inward_rays
+                inward_rays,
             )
             stellar_radiation_field.I_nus[:, :, theta_index] = I_nu
 
@@ -440,14 +442,13 @@ def raytrace(
         ) ** 2
         stellar_radiation_field.F_nu *= photospheric_correction  # Outermost radius is larger than the photosphere so need to downscale the flux
 
-
     return stellar_radiation_field.F_nu
 
 
 def calculate_spherical_ray(thetas, depth_points_radii):
     """
     Calculates the distance a ray travels through each layer of the star in spherical geometry.
-    
+
     Parameters
     ----------
     thetas : numpy.ndarray

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -89,7 +89,7 @@ def single_theta_trace_parallel(
     alphas,
     tracing_nus,
     source_function,
-    rays_inward=False,
+    inward_rays=False,
 ):
     """
     Performs ray tracing at an angle following van Noort 2001 eq 14.
@@ -106,6 +106,9 @@ def single_theta_trace_parallel(
         each depth point for each frequency in tracing_nus.
     tracing_nus : astropy.unit.quantity.Quantity
         Numpy array of frequencies used for ray tracing with units of Hz.
+    inward_rays : bool, optional
+        If True, rays are traced from the outermost layer to the innermost layer before the standard tracing
+        from the innermost layer to the outermost layer, by default False. Useful in spherical geometries. 
 
     Returns
     -------
@@ -134,9 +137,10 @@ def single_theta_trace_parallel(
 
     w0, w1, w2 = calc_weights_parallel(taus)
 
-    if rays_inward:
+    #In spherical geometry, for outside rays, you need to handle the ray that goes through the star and comes out the other side.
+    if inward_rays:
         for nu_index in numba.prange(len(tracing_nus)):
-            for gap_index in np.arange(no_of_depth_gaps - 1)[::-1]:
+            for gap_index in (np.arange(no_of_depth_gaps - 1) + 1)[::-1]:
                 # Start by solving all the weights and prefactors except the last jump which would go out of bounds
                 if taus[gap_index - 1, nu_index] == 0:
                     I_nu_theta[gap_index - 1, nu_index] = I_nu_theta[
@@ -191,7 +195,7 @@ def single_theta_trace_parallel(
                         + second_term
                         + third_term
                     )
-                I_nu_theta[1, nu_index] = I_nu_theta[2, nu_index]
+                #This is wrong, but probably doesn't matter. This is the innermost point of the star for an inward ray. 
                 I_nu_theta[0, nu_index] = I_nu_theta[1, nu_index]
 
     for nu_index in numba.prange(len(tracing_nus)):
@@ -272,6 +276,7 @@ def all_thetas_trace(
     tracing_nus,
     num_of_thetas,
     source_function,
+    inward_rays=False
 ):
     """
     Performs ray tracing at an angle following van Noort 2001 eq 14.
@@ -289,6 +294,9 @@ def all_thetas_trace(
     tracing_nus : astropy.unit.quantity.Quantity
         Numpy array of frequencies used for ray tracing with units of Hz.
     num_of_thetas : int
+    inward_rays : bool, optional
+        If True, rays are traced from the outermost layer to the innermost layer before the standard tracing
+        from the innermost layer to the outermost layer, by default False. Useful in spherical geomet
 
     Returns
     -------
@@ -332,7 +340,10 @@ def all_thetas_trace(
         )
         / (taus[gap_indices] + taus[gap_indices + 1])
     )
-
+    
+    if inward_rays:
+        pass
+    
     for gap_index in range(
         no_of_depth_gaps - 1
     ):  # solve the ray tracing equation out to the surface of the star, not including the last jump
@@ -370,8 +381,10 @@ def raytrace(
     stellar_model : stardis.model.base.StellarModel
     stellar_radiation_field : stardis.radiation_field.base.StellarRadiationField
         Contains temperatures, frequencies, and opacities needed to calculate F_nu.
-    no_of_thetas : int, optional
-        Number of angles to sample for ray tracing, by default 20.
+    spherical : bool, optional
+        If True, rays are traced from the outermost layer to the innermost layer before the standard tracing
+        from the innermost layer to the outermost layer, by default False. Distance of rays through
+        each the star is also calculated differently.
 
     Returns
     -------
@@ -384,15 +397,14 @@ def raytrace(
         ray_distances = calculate_spherical_ray(
             stellar_radiation_field.thetas, stellar_model.geometry.r
         )
-        photospheric_correction = (
-            stellar_model.geometry.r[-1] / stellar_model.geometry.reference_r
-        ) ** 2
+        inward_rays = True
     else:
         ray_distances = stellar_model.geometry.dist_to_next_depth_point.reshape(
             -1, 1
         ) / np.cos(stellar_radiation_field.thetas)
-
-    if n_threads == 1:  # Single threaded
+        inward_rays = False
+    if False: #Commenting out serial threaded block for now - currently doesn't work with spherical geometry and not sure it's worth maintaining
+    # if n_threads == 1:  # Single threaded
         stellar_radiation_field.I_nus = all_thetas_trace(
             ray_distances,
             stellar_model.temperatures.value.reshape(-1, 1),
@@ -400,12 +412,12 @@ def raytrace(
             stellar_radiation_field.frequencies,
             len(stellar_radiation_field.thetas),
             stellar_radiation_field.source_function,
+            inward_rays
         )
         stellar_radiation_field.F_nu = np.sum(
             stellar_radiation_field.I_nus_weights * stellar_radiation_field.I_nus,
             axis=2,
         )
-
     else:  # Parallel threaded
         for theta_index, theta in enumerate(stellar_radiation_field.thetas):
             I_nu = single_theta_trace_parallel(
@@ -414,6 +426,7 @@ def raytrace(
                 stellar_radiation_field.opacities.total_alphas,
                 stellar_radiation_field.frequencies,
                 stellar_radiation_field.source_function,
+                inward_rays
             )
             stellar_radiation_field.I_nus[:, :, theta_index] = I_nu
 
@@ -422,12 +435,26 @@ def raytrace(
             )
 
     if spherical:
+        photospheric_correction = (
+            stellar_model.geometry.r[-1] / stellar_model.geometry.reference_r
+        ) ** 2
         stellar_radiation_field.F_nu *= photospheric_correction  # Outermost radius is larger than the photosphere so need to downscale the flux
+
 
     return stellar_radiation_field.F_nu
 
 
 def calculate_spherical_ray(thetas, depth_points_radii):
+    """
+    Calculates the distance a ray travels through each layer of the star in spherical geometry.
+    
+    Parameters
+    ----------
+    thetas : numpy.ndarray
+        Array of angles in radians.
+    depth_points_radii : numpy.ndarray
+        Array of radii of each depth point in the star.
+    """
     # NOTE: May need to revisit for outer rays. Currently don't include the outer rays going through the far side of the star
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -467,15 +467,13 @@ def calculate_spherical_ray(thetas, depth_points_radii):
         (len(depth_points_radii) - 1, len(thetas))
     )
 
-    dr = np.diff(depth_points_radii)
     for theta_index, theta in enumerate(thetas):
         b = depth_points_radii[-1] * np.sin(theta)  # impact parameter of the ray
         ray_z_coordinate_grid = np.sqrt(
             depth_points_radii**2 - b**2
         )  # Rays that don't go deeper than a layer will have a nan here
 
-        ray_distance = dr * depth_points_radii[1:] / ray_z_coordinate_grid[1:]
-        # ray_distance = np.diff(ray_z_coordinate_grid)
+        ray_distance = np.diff(ray_z_coordinate_grid)
         ray_distance_through_layer_by_impact_parameter[
             ~np.isnan(ray_distance), theta_index
         ] = ray_distance[~np.isnan(ray_distance)]

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -372,7 +372,6 @@ def raytrace(
     stellar_model,
     stellar_radiation_field,
     n_threads=1,
-    spherical=False,
 ):
     """
     Raytraces over many angles and integrates to get flux using the midpoint
@@ -395,7 +394,7 @@ def raytrace(
         each depth_point for each frequency in tracing_nus.
     """
 
-    if spherical:
+    if stellar_model.spherical:
         ray_distances = calculate_spherical_ray(
             stellar_radiation_field.thetas, stellar_model.geometry.r
         )
@@ -438,7 +437,7 @@ def raytrace(
                 I_nu * stellar_radiation_field.I_nus_weights[theta_index]
             )
 
-    if spherical:
+    if stellar_model.spherical:
         photospheric_correction = (
             stellar_model.geometry.r[-1] / stellar_model.geometry.reference_r
         ) ** 2

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -455,7 +455,6 @@ def calculate_spherical_ray(thetas, depth_points_radii):
     depth_points_radii : numpy.ndarray
         Array of radii of each depth point in the star.
     """
-    # NOTE: May need to revisit for outer rays. Currently don't include the outer rays going through the far side of the star
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))
     )

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -142,10 +142,10 @@ def single_theta_trace_parallel(
         for nu_index in numba.prange(len(tracing_nus)):
             for gap_index in np.arange(0, no_of_depth_gaps)[::-1]:
                 # Start by solving all the weights and prefactors except the last jump which would go out of bounds
-                if (taus[gap_index, nu_index] == 0 or taus[gap_index - 1, nu_index] == 0):
-                        I_nu_theta[gap_index, nu_index] = I_nu_theta[
-                            gap_index + 1, nu_index
-                        ]  # If no optical depth, no change in intensity
+                if taus[gap_index, nu_index] == 0 or taus[gap_index - 1, nu_index] == 0:
+                    I_nu_theta[gap_index, nu_index] = I_nu_theta[
+                        gap_index + 1, nu_index
+                    ]  # If no optical depth, no change in intensity
                 else:
                     second_term = (
                         w1[gap_index, nu_index]
@@ -154,12 +154,18 @@ def single_theta_trace_parallel(
                                 source[gap_index, nu_index]
                                 - source[gap_index - 1, nu_index]
                             )
-                            * (taus[gap_index, nu_index] / taus[gap_index - 1, nu_index])
+                            * (
+                                taus[gap_index, nu_index]
+                                / taus[gap_index - 1, nu_index]
+                            )
                             - (
                                 source[gap_index, nu_index]
                                 - source[gap_index + 1, nu_index]
                             )
-                            * (taus[gap_index - 1, nu_index] / taus[gap_index, nu_index])
+                            * (
+                                taus[gap_index - 1, nu_index]
+                                / taus[gap_index, nu_index]
+                            )
                         )
                         / (taus[gap_index, nu_index] + taus[gap_index - 1, nu_index])
                     )
@@ -184,7 +190,8 @@ def single_theta_trace_parallel(
                     )
                     # Solve the raytracing equation for all points other than the final jump
                     I_nu_theta[gap_index, nu_index] = (
-                        (1 - w0[gap_index, nu_index]) * I_nu_theta[gap_index + 1, nu_index]
+                        (1 - w0[gap_index, nu_index])
+                        * I_nu_theta[gap_index + 1, nu_index]
                         + w0[gap_index, nu_index] * source[gap_index, nu_index]
                         + second_term
                         + third_term

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -447,7 +447,7 @@ def raytrace(
 
 def calculate_spherical_ray(thetas, depth_points_radii):
     """
-    Calculates the distance a ray travels through each layer of the star in spherical geometry.
+    Calculate the distance a ray travels between the depth points of the star in spherical geometry.
 
     Parameters
     ----------
@@ -455,19 +455,24 @@ def calculate_spherical_ray(thetas, depth_points_radii):
         Array of angles in radians.
     depth_points_radii : numpy.ndarray
         Array of radii of each depth point in the star.
+        
+    Returns
+    -------
+    ray_distance_through_layer_by_impact_parameter : numpy.ndarray
+        Array of shape (no_of_depth_points - 1, no_of_thetas). Distance a ray travels through each layer of the star
+        for each angle.
     """
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))
     )
-
+    
     for theta_index, theta in enumerate(thetas):
         b = depth_points_radii[-1] * np.sin(theta)  # impact parameter of the ray
         ray_z_coordinate_grid = np.sqrt(
             depth_points_radii**2 - b**2
         )  # Rays that don't go deeper than a layer will have a nan here
 
-        dr = np.diff(depth_points_radii)
-        ray_distance = dr * depth_points_radii[1:] / ray_z_coordinate_grid[1:]
+        ray_distance = np.diff(ray_z_coordinate_grid)
         ray_distance_through_layer_by_impact_parameter[
             ~np.isnan(ray_distance), theta_index
         ] = ray_distance[~np.isnan(ray_distance)]

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -468,14 +468,14 @@ def calculate_spherical_ray(thetas, depth_points_radii):
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))
     )
-    
+
     dr = np.diff(depth_points_radii)
     for theta_index, theta in enumerate(thetas):
         b = depth_points_radii[-1] * np.sin(theta)  # impact parameter of the ray
         ray_z_coordinate_grid = np.sqrt(
             depth_points_radii**2 - b**2
         )  # Rays that don't go deeper than a layer will have a nan here
-        
+
         ray_distance = dr * depth_points_radii[1:] / ray_z_coordinate_grid[1:]
         # ray_distance = np.diff(ray_z_coordinate_grid)
         ray_distance_through_layer_by_impact_parameter[

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -468,14 +468,16 @@ def calculate_spherical_ray(thetas, depth_points_radii):
     ray_distance_through_layer_by_impact_parameter = np.zeros(
         (len(depth_points_radii) - 1, len(thetas))
     )
-
+    
+    dr = np.diff(depth_points_radii)
     for theta_index, theta in enumerate(thetas):
         b = depth_points_radii[-1] * np.sin(theta)  # impact parameter of the ray
         ray_z_coordinate_grid = np.sqrt(
             depth_points_radii**2 - b**2
         )  # Rays that don't go deeper than a layer will have a nan here
-
-        ray_distance = np.diff(ray_z_coordinate_grid)
+        
+        ray_distance = dr * depth_points_radii[1:] / ray_z_coordinate_grid[1:]
+        # ray_distance = np.diff(ray_z_coordinate_grid)
         ray_distance_through_layer_by_impact_parameter[
             ~np.isnan(ray_distance), theta_index
         ] = ray_distance[~np.isnan(ray_distance)]

--- a/stardis/radiation_field/radiation_field_solvers/base.py
+++ b/stardis/radiation_field/radiation_field_solvers/base.py
@@ -83,7 +83,7 @@ def calc_weights(delta_tau):
 
 @numba.njit(parallel=True)
 def single_theta_trace_parallel(
-    geometry_dist_to_next_depth_point,
+    ray_dist_to_next_depth_point,
     temps,
     alphas,
     tracing_nus,
@@ -117,10 +117,14 @@ def single_theta_trace_parallel(
     # Need to calculate a mean opacity for the traversal between points. Linearly interporlating. Van Noort paper suggests interpolating
     # alphas in log space. We could have a choice for interpolation scheme here.
     mean_alphas = np.exp((np.log(alphas[1:]) + np.log(alphas[:-1])) * 0.5)
-    taus = (
-        mean_alphas * geometry_dist_to_next_depth_point.reshape(-1, 1) / np.cos(theta)
-    )
-    no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
+    
+    taus = np.zeros_like(mean_alphas, dtype=np.float64)
+    for gap_index in numba.prange(taus.shape[0]):
+        for nu_index in range(taus.shape[1]):
+            taus[gap_index, nu_index] = mean_alphas[gap_index, nu_index] * ray_dist_to_next_depth_point[gap_index]
+    
+    
+    no_of_depth_gaps = len(ray_dist_to_next_depth_point)
 
     source = source_function(tracing_nus, temps)
     I_nu_theta = np.zeros((no_of_depth_gaps + 1, len(tracing_nus)))
@@ -184,12 +188,14 @@ def single_theta_trace_parallel(
 
 
 def single_theta_trace(
-    geometry_dist_to_next_depth_point,
+    ray_dist_to_next_depth_point,
     temps,
     alphas,
     tracing_nus,
     thetas,
     source_function,
+    spherical = False,
+    reference_radius = 2.5e11,
 ):
     """
     Performs ray tracing at an angle following van Noort 2001 eq 14.
@@ -218,10 +224,11 @@ def single_theta_trace(
     # Need to calculate a mean opacity for the traversal between points. Linearly interporlating. Van Noort paper suggests interpolating
     # alphas in log space. We could have a choice for interpolation scheme here.
     mean_alphas = np.exp((np.log(alphas[1:]) + np.log(alphas[:-1])) * 0.5)
-    taus = (mean_alphas * geometry_dist_to_next_depth_point.reshape(-1, 1))[
-        :, :, np.newaxis
-    ] / np.cos(thetas)
-    no_of_depth_gaps = len(geometry_dist_to_next_depth_point)
+    if spherical:
+        pass
+    
+    taus = (mean_alphas[:,:, np.newaxis] * ray_dist_to_next_depth_point[:, np.newaxis, :])
+    no_of_depth_gaps = len(ray_dist_to_next_depth_point)
 
     source = source_function(tracing_nus, temps)[:, :, np.newaxis]
     I_nu_theta = np.zeros((no_of_depth_gaps + 1, len(tracing_nus), thetas.shape[2]))
@@ -270,7 +277,7 @@ def single_theta_trace(
     return I_nu_theta
 
 
-def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20, n_threads=1):
+def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20, n_threads=1, spherical=False, reference_radius=2.5e11):
     """
     Raytraces over many angles and integrates to get flux using the midpoint
     rule.
@@ -290,18 +297,29 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20, n_threads=
         each depth_point for each frequency in tracing_nus.
     """
 
-    dtheta = (np.pi / 2) / no_of_thetas
+    if spherical:
+        #Calculate photosphere correction - apply it later to F_nu
+        pass
+    else:
+        pass
+    dtheta = (np.pi / 2) / no_of_thetas #Korg uses Gauss-Legendre quadrature here
     start_theta = dtheta / 2
     end_theta = (np.pi / 2) - (dtheta / 2)
     thetas = np.linspace(start_theta, end_theta, no_of_thetas)
+    weights = 2 * np.pi * dtheta * np.sin(thetas) * np.cos(thetas)
+    
+    if spherical:
+        ray_depth_selection_mask, ray_distances = calculate_spherical_ray(thetas, stellar_model.geometry.r)
+    else: 
+        ray_distances = stellar_model.geometry.dist_to_next_depth_point.reshape(-1,1) / np.cos(thetas)
+    
 
     ###TODO: Thetas should probably be held by the model? Then can be passed in from there.
     if n_threads == 1:  # Single threaded
-        weights = 2 * np.pi * dtheta * np.sin(thetas) * np.cos(thetas)
         stellar_radiation_field.F_nu = np.sum(
             weights
             * single_theta_trace(
-                stellar_model.geometry.dist_to_next_depth_point,
+                ray_distances,
                 stellar_model.temperatures.value.reshape(-1, 1),
                 stellar_radiation_field.opacities.total_alphas,
                 stellar_radiation_field.frequencies,
@@ -312,10 +330,9 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20, n_threads=
         )
 
     else:  # Parallel threaded
-        for theta in thetas:
-            weight = 2 * np.pi * dtheta * np.sin(theta) * np.cos(theta)
-            stellar_radiation_field.F_nu += weight * single_theta_trace_parallel(
-                stellar_model.geometry.dist_to_next_depth_point,
+        for theta_index, theta in enumerate(thetas):
+            stellar_radiation_field.F_nu += weights[theta_index] * single_theta_trace_parallel(
+                ray_distances[:, theta_index],
                 stellar_model.temperatures.value.reshape(-1, 1),
                 stellar_radiation_field.opacities.total_alphas,
                 stellar_radiation_field.frequencies,
@@ -324,3 +341,11 @@ def raytrace(stellar_model, stellar_radiation_field, no_of_thetas=20, n_threads=
             )
 
     return stellar_radiation_field.F_nu
+
+def calculate_spherical_ray(theta, depth_points_radii):
+    ###NOTE: This will need to be revisited to handle some rays more carefully if they don't go through the star 
+    b = depth_points_radii[-1] * np.sin(theta) #impact parameter
+    ray_depth_selection_mask = b < depth_points_radii #mask for the depth points that the ray will pass through. 
+    #The layers the ray doesn't pass through will not contribute to the outgoing flux
+    ray_distance_to_next_depth_point = np.sqrt(depth_points_radii[ray_depth_selection_mask]**2 - b**2)
+    return(ray_depth_selection_mask, ray_distance_to_next_depth_point)


### PR DESCRIPTION
Our H2+ bound-free opacity table has a lower temperature bound of 3150 K, a temperature that is reasonably achievable in the outermost layers of cool stellar atmospheres. Scipy's LinearNDInterpolator defaults to nan, outside of the convex hull that it spans, which propagates to all of our opacities, and in turn to all of the fluxes. This PR changes that behavior to just assume that H2+ BF opacity does not contribute at these low temperatures, which isn't exactly physical but is better than the previous behavior of just not being able to run cool simulations with this opacity source turned on. 

Also applies the same patch to H- FF opacity. 