### PR TITLE
Fix NaNs for cool atmospheres with H2+BF and H-FF opacities enabled. 

### DIFF
--- a/stardis/radiation_field/opacities/opacities_solvers/util.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/util.py
@@ -46,6 +46,7 @@ def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
         linear_interp_h2plus_bf = LinearNDInterpolator(
             np.vstack([file_waves_mesh.ravel(), file_temps_mesh.ravel()]).T,
             file_cross_sections.flatten(),
+            fill_value=0,
         )
         lambdas, temps = np.meshgrid(tracing_lambdas, temperatures)
         sigmas = (
@@ -68,6 +69,7 @@ def sigma_file(tracing_lambdas, temperatures, fpath, opacity_source=None):
         linear_interp_hminus_ff = LinearNDInterpolator(
             np.vstack([file_waves_mesh.ravel(), file_thetas_mesh.ravel()]).T,
             file_values.flatten(),
+            fill_value=0,
         )
         lambdas, thetas = np.meshgrid(tracing_lambdas, 5040 / temperatures)
         sigmas = (


### PR DESCRIPTION
Our H2+ bound-free opacity table has a lower temperature bound of 3150 K, a temperature that is reasonably achievable in the outermost layers of cool stellar atmospheres. Scipy's LinearNDInterpolator defaults to nan, outside of the convex hull that it spans, which propagates to all of our opacities, and in turn to all of the fluxes. This PR changes that behavior to just assume that H2+ BF opacity does not contribute at these low temperatures, which isn't exactly physical but is better than the previous behavior of just not being able to run cool simulations with this opacity source turned on.

Also applies the same patch to H- FF opacity.
