### PR TITLE
add microturbulence to simulation

### DIFF
--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -109,7 +109,11 @@ properties:
                             - van_der_waals
                             - radiation
                         default: []
-                        description: Types of broadening to include.
+                        description: Types of broadening to include.                                              
+                    disable_microturbulence:
+                        type: boolean
+                        default: false
+                        description: Whether to disable microturbulence.
                     broadening_range:
                         type: [quantity, "null"]
                         default: null

--- a/stardis/io/base.py
+++ b/stardis/io/base.py
@@ -75,6 +75,8 @@ def parse_config_to_model(config_fname, add_config_dict):
         stellar_model = raw_marcs_model.to_stellar_model(
             adata, final_atomic_number=config.model.final_atomic_number
         )
+        if config.opacity.line.disable_microturbulence:
+            stellar_model.microturbulence = stellar_model.microturbulence * 0.0
 
     elif config.model.type == "mesa":
         raw_mesa_model = read_mesa_model(Path(config.model.fname))

--- a/stardis/io/model/marcs.py
+++ b/stardis/io/model/marcs.py
@@ -143,8 +143,12 @@ class MARCSModel(object):
         temperatures = (
             self.data.t.values[::-1] * u.K
         )  # Flip data to move from innermost stellar point to surface
-        # First two none values are old fv_geometry and abundances which are replaced by the new structures.
-        return StellarModel(temperatures, marcs_geometry, marcs_composition)
+        return StellarModel(
+            temperatures,
+            marcs_geometry,
+            marcs_composition,
+            microturbulence=self.metadata["microturbulence"],
+        )
 
 
 def read_marcs_metadata(fpath, gzipped=True):

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -21,14 +21,17 @@ class StellarModel(HDFWriterMixin):
         Composition of the model. Includes density and atomic mass fractions.
     no_of_depth_points : int
         Class attribute to be easily accessible for initializing arrays that need to match the shape of the model.
+    microturbulence : float
+        Microturbulence in km/s.
     """
 
     hdf_properties = ["temperatures", "geometry", "composition"]
 
-    def __init__(self, temperatures, geometry, composition):
+    def __init__(self, temperatures, geometry, composition, microturbulence=0.0):
         self.temperatures = temperatures
         self.geometry = geometry
         self.composition = composition
+        self.microturbulence = microturbulence
 
     @property
     def no_of_depth_points(self):

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -65,6 +65,7 @@ def test_calc_doppler_width_sample_values(
             calc_doppler_width_sample_values_input_nu_line,
             calc_doppler_width_sample_values_input_temperature,
             calc_doppler_width_sample_values_input_atomic_mass,
+            0.0,
         ),
         calc_doppler_width_sample_values_expected_result,
     )
@@ -519,7 +520,6 @@ def test_calc_gamma_van_der_waals_sample_values(
     calc_gamma_van_der_waals_sample_values_input_h_density,
     calc_gamma_van_der_waals_sample_values_expected_result,
 ):
-
     assert np.allclose(
         calc_gamma_van_der_waals(
             calc_gamma_van_der_waals_sample_values_input_ion_number,

--- a/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/tests/test_broadening.py
@@ -68,7 +68,7 @@ def test_calc_doppler_width_sample_values(
             0.0,
         ),
         calc_doppler_width_sample_values_expected_result,
-    )
+    )  # No microturbulence for legacy reasons - 0.0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
There's also an option in the config to disable microturbulence. 

Here's a solar spectrum of H-Alpha with microturbulence read from the Marcs model
![korg_micro](https://github.com/user-attachments/assets/602f934b-6b01-4dd7-9fb2-578b2e6d11ca)

Here's that with microturbulence disabled. 
![korg_micro_disabled](https://github.com/user-attachments/assets/708d1c0c-eb0b-428c-a530-f38588d1dd73)
