### PR TITLE
Alan cleanup

### DIFF
--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -131,7 +131,7 @@ properties:
                                 default: false
                             use_vald_broadening:
                                 type: boolean
-                                default: false
+                                default: True
                         description: Options for whether to use a vald linelist. Linelist must be included the atom_data and cannot be supplied separately. 
                     include_molecules:
                         type: boolean

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -129,6 +129,9 @@ properties:
                             shortlist:
                                 type: boolean
                                 default: false
+                            use_vald_broadening:
+                                type: boolean
+                                default: false
                         description: Options for whether to use a vald linelist. Linelist must be included the atom_data and cannot be supplied separately. 
                     include_molecules:
                         type: boolean

--- a/stardis/config_schema.yml
+++ b/stardis/config_schema.yml
@@ -131,7 +131,7 @@ properties:
                                 default: false
                             use_vald_broadening:
                                 type: boolean
-                                default: True
+                                default: true
                         description: Options for whether to use a vald linelist. Linelist must be included the atom_data and cannot be supplied separately. 
                     include_molecules:
                         type: boolean
@@ -146,7 +146,7 @@ properties:
         description: Number of angles to use in the simulation.
     result_options:
         type: object
-        additionalProperties: False
+        additionalProperties: false
         default: {}
         properties:
             return_model:
@@ -157,7 +157,7 @@ properties:
                 default: false
             return_radiation_field:
                 type: boolean
-                default: True
+                default: true
         description: Options for what to return from the simulation.
     required:
     - stardis_config_version

--- a/stardis/conftest.py
+++ b/stardis/conftest.py
@@ -250,7 +250,6 @@ def example_stellar_radiation_field_parallel(
         stellar_model=example_stellar_model,
         stellar_radiation_field=stellar_radiation_field,
         opacity_config=example_config_parallel.opacity,
-        n_threads=example_config_parallel.n_threads,
     )
 
     raytrace(

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -311,8 +311,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number
@@ -449,11 +449,12 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         return alphas, linelist
+
 
 # Properties that haven't been used in creating stellar plasma yet,
 # might be useful in future ----------------------------------------------------

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -311,8 +311,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (
-            linelist["rad"]
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number
@@ -449,15 +449,11 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (
-            linelist["rad"]
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
-        # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number
-        valid_indices = linelist.level_energy_upper < linelist.ionization_energy
-
-        return alphas[valid_indices], linelist[valid_indices]
-
+        return alphas, linelist
 
 # Properties that haven't been used in creating stellar plasma yet,
 # might be useful in future ----------------------------------------------------

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -311,8 +311,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
-            4 * np.pi
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number
@@ -449,8 +449,8 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
-            4 * np.pi
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number

--- a/stardis/plasma/base.py
+++ b/stardis/plasma/base.py
@@ -311,8 +311,8 @@ class AlphaLineVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number
@@ -449,8 +449,8 @@ class AlphaLineShortlistVald(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         # Need to remove autoionization lines - can't handle with current broadening treatment because can't calculate effective principal quantum number

--- a/stardis/plasma/molecules.py
+++ b/stardis/plasma/molecules.py
@@ -54,9 +54,7 @@ class MoleculeIonNumberDensity(ProcessingPlasmaProperty):
         for (
             molecule,
             molecule_row,
-        ) in (
-            molecules_df.iterrows()
-        ):  # Loop over all molecules, calculate number densities using Barklem and Collet 2016 equilibrium constants - if a component ion does not exist in the plasma or is negative, assume no molecule
+        ) in molecules_df.iterrows():  # Loop over all molecules, calculate number densities using Barklem and Collet 2016 equilibrium constants - if a component ion does not exist in the plasma or is negative, assume no molecule
             if (molecule_row.Ion1_charge == -1) or (molecule_row.Ion2_charge == -1):
                 logger.warning(
                     f"Negative ionic molecules not currently supported. Assuming no {molecule}."
@@ -288,8 +286,8 @@ class AlphaLineValdMolecule(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
-            4 * np.pi
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         return alphas, linelist
@@ -414,8 +412,8 @@ class AlphaLineShortlistValdMolecule(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = 10 ** (linelist["rad"]) / (
-            4 * np.pi
+        linelist["A_ul"] = (
+            10 ** (linelist["rad"])
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         return alphas, linelist

--- a/stardis/plasma/molecules.py
+++ b/stardis/plasma/molecules.py
@@ -54,7 +54,9 @@ class MoleculeIonNumberDensity(ProcessingPlasmaProperty):
         for (
             molecule,
             molecule_row,
-        ) in molecules_df.iterrows():  # Loop over all molecules, calculate number densities using Barklem and Collet 2016 equilibrium constants - if a component ion does not exist in the plasma or is negative, assume no molecule
+        ) in (
+            molecules_df.iterrows()
+        ):  # Loop over all molecules, calculate number densities using Barklem and Collet 2016 equilibrium constants - if a component ion does not exist in the plasma or is negative, assume no molecule
             if (molecule_row.Ion1_charge == -1) or (molecule_row.Ion2_charge == -1):
                 logger.warning(
                     f"Negative ionic molecules not currently supported. Assuming no {molecule}."
@@ -286,8 +288,8 @@ class AlphaLineValdMolecule(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         return alphas, linelist
@@ -412,8 +414,8 @@ class AlphaLineShortlistValdMolecule(ProcessingPlasmaProperty):
         linelist["level_energy_upper"] = ((linelist["e_up"].values * u.eV).cgs).value
 
         # Radiation broadening parameter is approximated as the einstein A coefficient. Vald parameters are in log scale.
-        linelist["A_ul"] = (
-            10 ** (linelist["rad"])
+        linelist["A_ul"] = 10 ** (
+            linelist["rad"]
         )  # see 1995A&AS..112..525P for appropriate units - may be off by a factor of 4pi
 
         return alphas, linelist

--- a/stardis/radiation_field/base.py
+++ b/stardis/radiation_field/base.py
@@ -77,7 +77,6 @@ def create_stellar_radiation_field(tracing_nus, stellar_model, stellar_plasma, c
         stellar_model=stellar_model,
         stellar_radiation_field=stellar_radiation_field,
         opacity_config=config.opacity,
-        n_threads=config.n_threads,
     )
     logger.info("Raytracing")
     raytrace(

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -411,7 +411,8 @@ def calc_alpha_line_at_nu(
         stellar_model,
         stellar_plasma,
         line_opacity_config.broadening,
-    )  # This can be further improved by only calculating the broadening for the lines that are within the range.
+        use_vald_broadening=line_opacity_config.vald_linelist.use_vald_broadening,
+    )
 
     delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
 
@@ -815,9 +816,9 @@ def calc_alphas(
         opacity_config.line,
         n_threads,
     )
-    stellar_radiation_field.opacities.opacities_dict[
-        "alpha_line_at_nu"
-    ] = alpha_line_at_nu
+    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
+        alpha_line_at_nu
+    )
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -406,6 +406,16 @@ def calc_alpha_line_at_nu(
         .to_numpy()
     )
 
+    if not line_opacity_config.vald_linelist.use_vald_broadening:
+        autoionization_lines = (
+            lines_sorted_in_range.level_energy_upper
+            > lines_sorted_in_range.ionization_energy
+        ).values
+
+        lines_sorted_in_range = lines_sorted_in_range[~autoionization_lines].copy()
+        alphas_array = alphas_array[~autoionization_lines].copy()
+        line_nus = line_nus[~autoionization_lines].copy()
+
     lines_sorted_in_range = lines_sorted_in_range.apply(
         pd.to_numeric
     )  # weird bug cropped up with ion_number being an object instead of an int

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -425,7 +425,8 @@ def calc_alpha_line_at_nu(
         stellar_model,
         stellar_plasma,
         line_opacity_config.broadening,
-        use_vald_broadening=line_opacity_config.vald_linelist.use_vald_broadening,
+        use_vald_broadening=line_opacity_config.vald_linelist.use_vald_broadening
+        and line_opacity_config.vald_linelist.use_linelist,  # don't try to use vald broadening if you don't use vald linelists at all
     )
 
     delta_nus = tracing_nus.value - line_nus[:, np.newaxis]

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -431,8 +431,16 @@ def calc_alpha_line_at_nu(
         use_vald_broadening=line_opacity_config.vald_linelist.use_vald_broadening
         and line_opacity_config.vald_linelist.use_linelist,  # don't try to use vald broadening if you don't use vald linelists at all
     )
-    logger.info("Done with broadening")
-    delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
+
+    # This line is awful for large simulations. Has to solve wavelength points times number of lines. Can be optimized.
+    # delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
+
+    # Ensure arrays are contiguous
+    tracing_nus_value = np.ascontiguousarray(tracing_nus.value)
+    line_nus_reshaped = np.ascontiguousarray(line_nus[:, np.newaxis])
+
+    # Perform the operation
+    delta_nus = tracing_nus_value - line_nus_reshaped
 
     # If no broadening range, compute the contribution of every line at every frequency.
     h_lines_indices = None
@@ -448,7 +456,7 @@ def calc_alpha_line_at_nu(
         if line_range.unit.physical_type == "length":
             logger.info("Broadening range is in length units")
             lambdas = tracing_nus.to(u.AA, equivalencies=u.spectral())
-            logger.info("Convering broadening to frequency units")
+            logger.info("Converting broadening to frequency units")
             lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)
             nus_plus_broadening_range = lambdas_plus_broadening_range.to(
                 u.Hz, equivalencies=u.spectral()

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -406,10 +406,8 @@ def calc_alpha_line_at_nu(
         .to_numpy()
     )
 
-    lines_sorted_in_range.loc[:, "ion_number"] = lines_sorted_in_range[
-        "ion_number"
-    ].astype(
-        int
+    lines_sorted_in_range = lines_sorted_in_range.apply(
+        pd.to_numeric
     )  # weird bug cropped up with ion_number being an object instead of an int
 
     gammas, doppler_widths = calculate_broadening(
@@ -491,6 +489,7 @@ def calc_molecular_alpha_line_at_nu(
     lines_sorted_in_range = lines_sorted[
         lines_sorted.nu.between(tracing_nus.min(), tracing_nus.max())
     ]
+
     line_nus = lines_sorted_in_range.nu.to_numpy()
 
     alphas_and_nu = stellar_plasma.molecule_alpha_line_from_linelist

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -433,14 +433,7 @@ def calc_alpha_line_at_nu(
     )
 
     # This line is awful for large simulations. Has to solve wavelength points times number of lines. Can be optimized.
-    # delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
-
-    # Ensure arrays are contiguous
-    tracing_nus_value = np.ascontiguousarray(tracing_nus.value)
-    line_nus_reshaped = np.ascontiguousarray(line_nus[:, np.newaxis])
-
-    # Perform the operation
-    delta_nus = tracing_nus_value - line_nus_reshaped
+    delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
 
     # If no broadening range, compute the contribution of every line at every frequency.
     h_lines_indices = None
@@ -454,9 +447,7 @@ def calc_alpha_line_at_nu(
             lines_sorted_in_range.atomic_number == 1
         ).to_numpy()  # Hydrogen lines are much broader than other lines, so they need special treatment to ignore the broadening range.
         if line_range.unit.physical_type == "length":
-            logger.info("Broadening range is in length units")
             lambdas = tracing_nus.to(u.AA, equivalencies=u.spectral())
-            logger.info("Converting broadening to frequency units")
             lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)
             nus_plus_broadening_range = lambdas_plus_broadening_range.to(
                 u.Hz, equivalencies=u.spectral()
@@ -469,7 +460,6 @@ def calc_alpha_line_at_nu(
                 "Broadening range must be in units of length or frequency."
             )
 
-    logger.info("Calculating alphas at nus.")
     if n_threads == 1:  # Single threaded
         alpha_line_at_nu = calc_alan_entries(
             stellar_model.no_of_depth_points,

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -449,7 +449,7 @@ def calc_alpha_line_at_nu(
             logger.info("Broadening range is in length units")
             lambdas = tracing_nus.to(u.AA, equivalencies=u.spectral())
             logger.info("Convering broadening to frequency units")
-            lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)")
+            lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)
             nus_plus_broadening_range = lambdas_plus_broadening_range.to(
                 u.Hz, equivalencies=u.spectral()
             )

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -423,7 +423,6 @@ def calc_alpha_line_at_nu(
         pd.to_numeric
     )  # weird bug cropped up with ion_number being an object instead of an int
 
-    logger.info("Calculating broadening parameters.")
     gammas, doppler_widths = calculate_broadening(
         lines_sorted_in_range,
         stellar_model,

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -816,9 +816,9 @@ def calc_alphas(
         opacity_config.line,
         n_threads,
     )
-    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
-        alpha_line_at_nu
-    )
+    stellar_radiation_field.opacities.opacities_dict[
+        "alpha_line_at_nu"
+    ] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -647,82 +647,82 @@ def calc_molecular_alpha_line_at_nu(
 #     return alpha_line_at_nu
 
 
-@numba.njit
-def calc_alan_entries(
-    no_of_depth_points,
-    tracing_nus_values,
-    delta_nus,
-    doppler_widths,
-    gammas,
-    alphas_array,
-    broadening_range=None,
-    h_lines_indices=None,
-):
-    """
-    This is a helper function to prepare appropriate calling of the voigt profile calculation and allow for structure that
-    can be parallelized. In the no broadening case it simply calls the voigt profile calculator with the appropriate structure.
-    In the broadening case it first creates a mask to only consider lines within the broadening range, and then calls the function
-    only on those lines. The variable line would make the input matrix not square, and prohibits easy access with numba, so an
-    explicit for loop must be called.
-
-    Parameters
-    ----------
-    no_of_depth_points : int
-        The number of depth points.
-    tracing_nus_values : array
-        The frequencies at which to calculate the Alan entries.
-    delta_nus : array
-        The differences between the frequencies and the line frequencies.
-    doppler_widths : array
-        The Doppler widths for each frequency.
-    gammas : array
-        The damping constants for each frequency.
-    alphas_array : array
-        The array of alpha values.
-    broadening_range : array, optional
-        The broadening range for each frequency. If provided, only frequencies within
-        this range will be considered. Default is None.
-    h_lines_indices : array, optional
-        The indices of the hydrogen lines. If provided, these lines will always be
-        considered, regardless of the broadening range. Default is None.
-
-    Returns
-    -------
-    alpha_line_at_nu : array
-        The calculated Alan entries for each frequency in `tracing_nus_values`.
-
-    """
-
-    alpha_line_at_nu = np.zeros((no_of_depth_points, len(tracing_nus_values)))
-
-    if broadening_range is None:
-        for frequency_index in numba.prange(len(tracing_nus_values)):
-            alpha_line_at_nu[:, frequency_index] = _calc_alan_entries(
-                delta_nus[:, frequency_index, np.newaxis],
-                doppler_widths,
-                gammas,
-                alphas_array,
-            )
-
-    else:
-        for frequency_index in numba.prange(len(tracing_nus_values)):
-            broadening_mask = (
-                np.abs(delta_nus[:, frequency_index])
-                < broadening_range[frequency_index]
-            )
-            broadening_mask = np.logical_or(broadening_mask, h_lines_indices)
-
-            alpha_line_at_nu[:, frequency_index] = _calc_alan_entries(
-                delta_nus[:, frequency_index, np.newaxis][broadening_mask],
-                doppler_widths[broadening_mask],
-                gammas[broadening_mask],
-                alphas_array[broadening_mask],
-            )
-
-    return alpha_line_at_nu
-
-
 # @numba.njit
+# def calc_alan_entries(
+#     no_of_depth_points,
+#     tracing_nus_values,
+#     delta_nus,
+#     doppler_widths,
+#     gammas,
+#     alphas_array,
+#     broadening_range=None,
+#     h_lines_indices=None,
+# ):
+#     """
+#     This is a helper function to prepare appropriate calling of the voigt profile calculation and allow for structure that
+#     can be parallelized. In the no broadening case it simply calls the voigt profile calculator with the appropriate structure.
+#     In the broadening case it first creates a mask to only consider lines within the broadening range, and then calls the function
+#     only on those lines. The variable line would make the input matrix not square, and prohibits easy access with numba, so an
+#     explicit for loop must be called.
+
+#     Parameters
+#     ----------
+#     no_of_depth_points : int
+#         The number of depth points.
+#     tracing_nus_values : array
+#         The frequencies at which to calculate the Alan entries.
+#     delta_nus : array
+#         The differences between the frequencies and the line frequencies.
+#     doppler_widths : array
+#         The Doppler widths for each frequency.
+#     gammas : array
+#         The damping constants for each frequency.
+#     alphas_array : array
+#         The array of alpha values.
+#     broadening_range : array, optional
+#         The broadening range for each frequency. If provided, only frequencies within
+#         this range will be considered. Default is None.
+#     h_lines_indices : array, optional
+#         The indices of the hydrogen lines. If provided, these lines will always be
+#         considered, regardless of the broadening range. Default is None.
+
+#     Returns
+#     -------
+#     alpha_line_at_nu : array
+#         The calculated Alan entries for each frequency in `tracing_nus_values`.
+
+#     """
+
+#     alpha_line_at_nu = np.zeros((no_of_depth_points, len(tracing_nus_values)))
+
+#     if broadening_range is None:
+#         for frequency_index in numba.prange(len(tracing_nus_values)):
+#             alpha_line_at_nu[:, frequency_index] = _calc_alan_entries(
+#                 delta_nus[:, frequency_index, np.newaxis],
+#                 doppler_widths,
+#                 gammas,
+#                 alphas_array,
+#             )
+
+#     else:
+#         for frequency_index in numba.prange(len(tracing_nus_values)):
+#             broadening_mask = (
+#                 np.abs(delta_nus[:, frequency_index])
+#                 < broadening_range[frequency_index]
+#             )
+#             broadening_mask = np.logical_or(broadening_mask, h_lines_indices)
+
+#             alpha_line_at_nu[:, frequency_index] = _calc_alan_entries(
+#                 delta_nus[:, frequency_index, np.newaxis][broadening_mask],
+#                 doppler_widths[broadening_mask],
+#                 gammas[broadening_mask],
+#                 alphas_array[broadening_mask],
+#             )
+
+#     return alpha_line_at_nu
+
+
+@numba.njit
 def calc_alan_entries(
     no_of_depth_points,
     tracing_nus_values,
@@ -778,44 +778,20 @@ def calc_alan_entries(
                 np.abs(tracing_nus_values - line_nu)
             )  # Maybe speed this up with binary search.
             # We could also use the information that we will always move one direction in frequency, because the line frequencies are sorted.
-            lower_freq_index = np.max(
-                (closest_frequency_index - 250, 0)
-            )  # Be cleverer incorporating alpha, gamma, and doppler width
-            upper_freq_index = np.min(
-                (closest_frequency_index + 250, len(tracing_nus_values))
-            )  # Be cleverer
+            lower_freq_index = np.array([closest_frequency_index - 1000, 0]).max()
+            # Be cleverer incorporating alpha, gamma, and doppler width
+            upper_freq_index = np.array(
+                [closest_frequency_index + 1000, len(tracing_nus_values)]
+            ).max()  # Be cleverer
             delta_nus = tracing_nus_values[lower_freq_index:upper_freq_index] - line_nu
-
-            try:
-                ans = _calc_alan_entries(
+            alpha_line_at_nu[depth_point_index, lower_freq_index:upper_freq_index] += (
+                _calc_alan_entries(
                     delta_nus,
                     doppler_widths[line_index, depth_point_index],
                     gammas[line_index, depth_point_index],
                     alphas_array[line_index, depth_point_index],
                 )
-            except:
-                print(
-                    gammas.shape,
-                )
-
-            alpha_line_at_nu[depth_point_index, lower_freq_index:upper_freq_index] += (
-                ans
             )
-
-    #         for frequency_index in numba.prange(len(tracing_nus_values)):
-    #             broadening_mask = (
-    #                 np.abs(delta_nus[:, frequency_index])
-    #                 < broadening_range[frequency_index]
-    #             )
-    #             broadening_mask = np.logical_or(broadening_mask, h_lines_indices)
-
-    #             alpha_line_at_nu[:, frequency_index] = _calc_alan_entries(
-    #                 delta_nus[:, frequency_index, np.newaxis][broadening_mask],
-    #                 doppler_widths[broadening_mask],
-    #                 gammas[broadening_mask],
-    #                 alphas_array[broadening_mask],
-    #             )
-
     return alpha_line_at_nu
 
 
@@ -851,7 +827,7 @@ def _calc_alan_entries(
         delta_nus, doppler_widths_at_depth_point, gammas_at_depth_point
     )
 
-    return np.sum(phis * alphas_at_depth_point, axis=0)
+    return phis * alphas_at_depth_point
 
 
 def calc_alphas(

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -407,7 +407,9 @@ def calc_alpha_line_at_nu(
         .to_numpy()
     )
 
-    lines_sorted_in_range["ion_number"] = lines_sorted_in_range["ion_number"].astype(
+    lines_sorted_in_range.loc[:, "ion_number"] = lines_sorted_in_range[
+        "ion_number"
+    ].astype(
         int
     )  # weird bug cropped up with ion_number being an object instead of an int
 

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -368,6 +368,7 @@ def calc_alpha_line_at_nu(
         # add ionization energy to lines
         ionization_data = stellar_plasma.ionization_data.reset_index()
         ionization_data["ion_number"] -= 1
+        ionization_data["ion_number"] = ionization_data["ion_number"]
         lines = pd.merge(
             lines, ionization_data, how="left", on=["atomic_number", "ion_number"]
         )
@@ -405,6 +406,10 @@ def calc_alpha_line_at_nu(
         .drop(labels="nu", axis=1)
         .to_numpy()
     )
+
+    lines_sorted_in_range["ion_number"] = lines_sorted_in_range["ion_number"].astype(
+        int
+    )  # weird bug cropped up with ion_number being an object instead of an int
 
     gammas, doppler_widths = calculate_broadening(
         lines_sorted_in_range,
@@ -816,9 +821,9 @@ def calc_alphas(
         opacity_config.line,
         n_threads,
     )
-    stellar_radiation_field.opacities.opacities_dict[
-        "alpha_line_at_nu"
-    ] = alpha_line_at_nu
+    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
+        alpha_line_at_nu
+    )
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -368,7 +368,6 @@ def calc_alpha_line_at_nu(
         # add ionization energy to lines
         ionization_data = stellar_plasma.ionization_data.reset_index()
         ionization_data["ion_number"] -= 1
-        ionization_data["ion_number"] = ionization_data["ion_number"]
         lines = pd.merge(
             lines, ionization_data, how="left", on=["atomic_number", "ion_number"]
         )

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -831,9 +831,9 @@ def calc_alphas(
         opacity_config.line,
         n_threads,
     )
-    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
-        alpha_line_at_nu
-    )
+    stellar_radiation_field.opacities.opacities_dict[
+        "alpha_line_at_nu"
+    ] = alpha_line_at_nu
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -548,9 +548,7 @@ def calc_alan_entries(
                     line_index, depth_point_index
                 ]  # Scale by alpha of the line
             ) / d_nu
-            line_broadening_range = np.array(
-                [10, line_broadening]
-            ).max()  # This is a placeholder
+            line_broadening_range = max(10.0, line_broadening)  # This is a placeholder
 
             lower_freq_index = max(
                 closest_frequency_index - int(line_broadening_range), 0

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -431,7 +431,7 @@ def calc_alpha_line_at_nu(
         use_vald_broadening=line_opacity_config.vald_linelist.use_vald_broadening
         and line_opacity_config.vald_linelist.use_linelist,  # don't try to use vald broadening if you don't use vald linelists at all
     )
-
+    logger.info("Done with broadening")
     delta_nus = tracing_nus.value - line_nus[:, np.newaxis]
 
     # If no broadening range, compute the contribution of every line at every frequency.
@@ -446,8 +446,10 @@ def calc_alpha_line_at_nu(
             lines_sorted_in_range.atomic_number == 1
         ).to_numpy()  # Hydrogen lines are much broader than other lines, so they need special treatment to ignore the broadening range.
         if line_range.unit.physical_type == "length":
+            logger.info("Broadening range is in length units")
             lambdas = tracing_nus.to(u.AA, equivalencies=u.spectral())
-            lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)
+            logger.info("Convering broadening to frequency units")
+            lambdas_plus_broadening_range = lambdas + line_range.to(u.AA)")
             nus_plus_broadening_range = lambdas_plus_broadening_range.to(
                 u.Hz, equivalencies=u.spectral()
             )

--- a/stardis/radiation_field/opacities/opacities_solvers/base.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/base.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 import numba
+import logging
 
 from astropy import units as u, constants as const
 
@@ -31,6 +32,8 @@ FF_CONSTANT = (
     * np.sqrt(2 * np.pi / (3 * const.m_e.cgs**3 * const.k_B.cgs))
 ).value
 RYDBERG_FREQUENCY = (const.c.cgs * const.Ryd.cgs).value
+
+logger = logging.getLogger(__name__)
 
 
 # Calculate opacity from any table specified by the user
@@ -420,6 +423,7 @@ def calc_alpha_line_at_nu(
         pd.to_numeric
     )  # weird bug cropped up with ion_number being an object instead of an int
 
+    logger.info("Calculating broadening parameters.")
     gammas, doppler_widths = calculate_broadening(
         lines_sorted_in_range,
         stellar_model,
@@ -456,6 +460,7 @@ def calc_alpha_line_at_nu(
                 "Broadening range must be in units of length or frequency."
             )
 
+    logger.info("Calculating alphas at nus.")
     if n_threads == 1:  # Single threaded
         alpha_line_at_nu = calc_alan_entries(
             stellar_model.no_of_depth_points,
@@ -542,7 +547,6 @@ def calc_molecular_alpha_line_at_nu(
             raise ValueError(
                 "Broadening range must be in units of length or frequency."
             )
-
     if n_threads == 1:  # Single threaded
         alpha_line_at_nu = calc_alan_entries(
             stellar_model.no_of_depth_points,
@@ -832,9 +836,9 @@ def calc_alphas(
         opacity_config.line,
         n_threads,
     )
-    stellar_radiation_field.opacities.opacities_dict[
-        "alpha_line_at_nu"
-    ] = alpha_line_at_nu
+    stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu"] = (
+        alpha_line_at_nu
+    )
     stellar_radiation_field.opacities.opacities_dict["alpha_line_at_nu_gammas"] = gammas
     stellar_radiation_field.opacities.opacities_dict[
         "alpha_line_at_nu_doppler_widths"

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -870,6 +870,9 @@ def rotation_broadening(
 
 
 def calc_vald_stark_gamma(electron_density, stark, temperature):
+    """ 
+    see 
+    """
     stark_gamma = electron_density * 10**stark * (temperature / 1e4) ** (1 / 6)
     stark_gamma = np.where(electron_density * stark >= 0, 0, stark_gamma)
     return stark_gamma
@@ -877,10 +880,10 @@ def calc_vald_stark_gamma(electron_density, stark, temperature):
 
 def _calc_vald_vdW_scaled_gamma(vdW, temperature):
     """
-    see https://github.com/barklem/public-data/tree/master/broadening-howto
+    see https://github.com/barklem/public-data/tree/master/broadening-howto, https://articles.adsabs.harvard.edu/pdf/1995MNRAS.276..859A
     and Korg https://github.com/ajwheeler/Korg.jl/blob/ff89e57b5f90b06553c10aebacedcb649a451f0b/src/line_absorption.jl#L178
     """
-    return (10**vdW * (temperature / 1e4) ** 0.3).T
+    return (10**vdW * (temperature / 1e4) ** 0.38).T
 
 
 def _calc_vald_vdw_unsoeld_approx(
@@ -950,8 +953,21 @@ def calc_vald_vdW(
 
     Parameters
     ----------
-    vdW : float
+    vdW : numpy.ndarray
         van der Waals broadening parameter.
+    temperature : numpy.ndarray
+        Temperature of depth points being considered.
+    atomic_mass : numpy.ndarray
+    upper_level_energy : numpy.ndarray
+        Energy in ergs of upper level of transition being considered.
+    lower_level_energy : numpy.ndarray
+        Energy in ergs of upper level of transition being considered.
+    hydrogen_density : numpy.ndarray
+        Number density of Hydrogen at depth point being considered.
+    ion_number : numpy.ndarray
+        Ion number + 1 of ion being considered. Treats interior as hydrogenic.
+    ionization_energy : numpy.ndarray
+        Ionization energy in ergs of ion being considered.
     """
     vdW_unscaled_mask = vdW < 0
     vdW_0_mask = vdW == 0.0
@@ -1019,12 +1035,12 @@ def calc_vald_gamma(
     if linear_stark:
         h_indices = lines.atomic_number == 1
         n_eff_upper = calc_n_effective(
-            1,
+            lines.ion_number[h_indices].values + 1,
             lines.ionization_energy[h_indices].values,
             lines.level_energy_upper[h_indices].values,
         )
         n_eff_lower = calc_n_effective(
-            1,
+            lines.ion_number[h_indices].values + 1,
             lines.ionization_energy[h_indices].values,
             lines.level_energy_lower[h_indices].values,
         )

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -989,6 +989,30 @@ def calc_vald_gamma(
     van_der_waals,
     radiation,
 ):
+    """
+    Calculates broadening information for vald lines at each depth point.
+
+    Parameters
+    ----------
+    lines : DataFrame
+        Dataframe of the lines to calculate broadening for.
+    stellar_model : stardis.model.base.StellarModel
+    stellar_plasma : tardis.plasma.base.BasePlasma
+    linear_stark : bool
+        True if linear Stark broadening is to be considered, otherwise False.
+    quadratic_stark : bool
+        True if quadratic Stark broadening is to be considered, otherwise False.
+    van_der_waals : bool
+        True if Van Der Waals broadening is to be considered, otherwise False.
+    radiation : bool
+        True if radiation broadening is to be considered, otherwise False.
+
+    Returns
+    -------
+    gammas : numpy.ndarray
+        Array of shape (no_of_lines, no_depth_points). Collisional broadening
+        parameter of each line at each depth point.
+    """
     gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
     if radiation:
         gammas += lines.A_ul.values[:, np.newaxis]

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -1017,8 +1017,23 @@ def calc_vald_gamma(
     if radiation:
         gammas += lines.A_ul.values[:, np.newaxis]
     if linear_stark:
-        hydrogen_stark_gammas = 0
-        gammas += hydrogen_stark_gammas
+        h_indices = lines.atomic_number == 1
+        n_eff_upper = calc_n_effective(
+            1,
+            lines.ionization_energy[h_indices].values,
+            lines.level_energy_upper[h_indices].values,
+        )
+        n_eff_lower = calc_n_effective(
+            1,
+            lines.ionization_energy[h_indices].values,
+            lines.level_energy_lower[h_indices].values,
+        )
+        gamma_linear_stark = calc_gamma_linear_stark(
+            n_eff_upper,
+            n_eff_lower,
+            stellar_plasma.electron_densities.values,
+        )
+        gammas[h_indices, :] += gamma_linear_stark
     if quadratic_stark:
         stark = calc_vald_stark_gamma(
             stellar_plasma.electron_densities.values,

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -1035,8 +1035,10 @@ def calc_vald_gamma(
     """
     gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
     if radiation:
+        logger.info("Calculating radiation broadening.")
         gammas += lines.A_ul.values[:, np.newaxis]
     if linear_stark:
+        logger.info("Calculating linear Stark broadening.")
         h_indices = lines.atomic_number == 1
         n_eff_upper = calc_n_effective(
             lines.ion_number[h_indices].values + 1,
@@ -1055,6 +1057,7 @@ def calc_vald_gamma(
         )
         gammas[h_indices, :] += gamma_linear_stark
     if quadratic_stark:
+        logger.info("Calculating quadratic Stark broadening.")
         stark = calc_vald_stark_gamma(
             stellar_plasma.electron_densities.values,
             lines.stark.values[:, np.newaxis],
@@ -1062,6 +1065,7 @@ def calc_vald_gamma(
         )
         gammas += stark
     if van_der_waals:
+        logger.info("Calculating van der Waals broadening.")
         vdW = calc_vald_vdW(
             lines.waals.values,
             stellar_model.temperatures.value,

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -1035,10 +1035,8 @@ def calc_vald_gamma(
     """
     gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
     if radiation:
-        logger.info("Calculating radiation broadening.")
         gammas += lines.A_ul.values[:, np.newaxis]
     if linear_stark:
-        logger.info("Calculating linear Stark broadening.")
         h_indices = lines.atomic_number == 1
         n_eff_upper = calc_n_effective(
             lines.ion_number[h_indices].values + 1,
@@ -1057,7 +1055,6 @@ def calc_vald_gamma(
         )
         gammas[h_indices, :] += gamma_linear_stark
     if quadratic_stark:
-        logger.info("Calculating quadratic Stark broadening.")
         stark = calc_vald_stark_gamma(
             stellar_plasma.electron_densities.values,
             lines.stark.values[:, np.newaxis],
@@ -1065,7 +1062,6 @@ def calc_vald_gamma(
         )
         gammas += stark
     if van_der_waals:
-        logger.info("Calculating van der Waals broadening.")
         vdW = calc_vald_vdW(
             lines.waals.values,
             stellar_model.temperatures.value,

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -1035,7 +1035,7 @@ def calc_vald_gamma(
     """
     gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
     if radiation:
-        gammas += lines.A_ul.values[:, np.newaxis]
+        gammas += np.broadcast_to(lines.A_ul.values.reshape(-1, 1), gammas.shape)
     if linear_stark:
         h_indices = lines.atomic_number == 1
         n_eff_upper = calc_n_effective(

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -873,7 +873,7 @@ def _calc_vald_vdw_unsoeld_approx(
             temperature
         ),  # This is just saying hydrogen density is 1. We multiply by hydrogen density later for all types of vdW broadening
     )
-    return vdW * approx_gamma
+    return vdW[:, np.newaxis] * approx_gamma
 
 
 def _calc_vald_vdW_abo(vdW, temperature, atomic_mass):

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -776,8 +776,9 @@ def calculate_molecule_broadening(
     quadratic_stark = "quadratic_stark" in broadening_line_opacity_config
     van_der_waals = "van_der_waals" in broadening_line_opacity_config
     radiation = "radiation" in broadening_line_opacity_config
+
+    gammas = np.zeros((len(lines), stellar_model.no_of_depth_points), dtype=float)
     if use_vald_broadening:
-        gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
         if radiation:
             gammas += lines.A_ul.values[:, np.newaxis]
         if linear_stark or quadratic_stark:
@@ -802,8 +803,6 @@ def calculate_molecule_broadening(
             )
             gammas += vdW
         gammas /= 2  # FWHM to HWHM
-    else:
-        gammas = np.zeros((len(lines), stellar_model.no_of_depth_points), dtype=float)
 
     ions = stellar_plasma.molecule_ion_map.loc[lines.molecule]
 

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -873,7 +873,8 @@ def _calc_vald_vdw_unsoeld_approx(
             temperature
         ),  # This is just saying hydrogen density is 1. We multiply by hydrogen density later for all types of vdW broadening
     )
-    return vdW[:, np.newaxis] * approx_gamma
+
+    return approx_gamma * vdW[:, np.newaxis]
 
 
 def _calc_vald_vdW_abo(vdW, temperature, atomic_mass):
@@ -886,7 +887,8 @@ def _calc_vald_vdW_abo(vdW, temperature, atomic_mass):
     vdW_int = vdW.astype(int)
     sigma = (vdW_int * BOHR_RADIUS * BOHR_RADIUS)[:, np.newaxis]
     alpha = (vdW - vdW_int)[:, np.newaxis]
-    inverse_reduced_mass = (1 / 1.008 * AMU_CGS) + (1 / atomic_mass)
+
+    inverse_reduced_mass = 1 / (1.008 * AMU_CGS) + (1 / atomic_mass)
     vbar = np.sqrt(8 * BOLTZMANN_CONSTANT * temperature / PI * inverse_reduced_mass)
     return (
         2

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -878,9 +878,8 @@ def rotation_broadening(
 
 def calc_vald_stark_gamma(electron_density, stark, temperature):
     stark_gamma = electron_density * 10**stark * (temperature / 1e4) ** (1 / 6)
-    # PRETTY SURE STARK IS WRONG, WAY TOO BROAD
-    np.where(stark * temperature == 0.0, 0.0, stark_gamma)
-    return stark_gamma  # * 1e-6
+    stark_gamma = np.where(electron_density * stark >= 0, 0, stark_gamma)
+    return stark_gamma
 
 
 def _calc_vald_vdW_scaled_gamma(vdW, temperature):
@@ -985,5 +984,4 @@ def calc_vald_vdW(
     gamma_vdW[vdW_abo_mask, :] = _calc_vald_vdW_abo(
         vdW[vdW_abo_mask], temperature, atomic_mass[vdW_abo_mask]
     )
-
     return gamma_vdW * hydrogen_density

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -4,6 +4,7 @@ import math
 import numba
 from numba import cuda
 from scipy.ndimage import convolve1d
+from scipy.special import gamma as gamma_func
 
 GPUs_available = cuda.is_available()
 
@@ -21,6 +22,7 @@ BOHR_RADIUS = float(const.a0.cgs.value)
 VACUUM_ELECTRIC_PERMITTIVITY = 1.0 / (4.0 * PI)
 H_MASS = float(const.m_p.cgs.value)
 C_KMS = float(const.c.to(u.km / u.s).value)
+AMU_CGS = const.u.cgs.value
 
 
 @numba.njit
@@ -655,6 +657,7 @@ def calculate_broadening(
     stellar_model,
     stellar_plasma,
     broadening_line_opacity_config,
+    use_vald_broadening=False,
 ):
     """
     Calculates broadening information for each line at each depth point.
@@ -667,6 +670,7 @@ def calculate_broadening(
     stellar_plasma : tardis.plasma.base.BasePlasma
     broadening_line_opacity_config : tardis.io.configuration.config_reader.Configuration
         Broadening methods section of the line opacity section of the STARDIS configuration.
+    use_vald_broadening : bool, optional
 
     Returns
     -------
@@ -681,22 +685,43 @@ def calculate_broadening(
     quadratic_stark = "quadratic_stark" in broadening_line_opacity_config
     van_der_waals = "van_der_waals" in broadening_line_opacity_config
     radiation = "radiation" in broadening_line_opacity_config
+    if use_vald_broadening:
+        gammas = np.zeros((lines.shape[0], stellar_model.no_of_depth_points))
+        if radiation:
+            gammas += lines.A_ul.values[:, np.newaxis]
+        if linear_stark or quadratic_stark:
+            stark = 10 ** lines.stark.values[:, np.newaxis]
+            gammas += stark
+        if van_der_waals:
+            gammas += calc_vald_vdW(
+                lines.waals.values,
+                stellar_model.temperatures.value,
+                stellar_model.composition.nuclide_masses.loc[
+                    lines.atomic_number
+                ].values[:, np.newaxis],
+                lines.level_energy_upper.values[:, np.newaxis],
+                lines.level_energy_lower.values[:, np.newaxis],
+                stellar_plasma.ion_number_density.loc[1, 0].values,
+                lines.ion_number.values[:, np.newaxis] + 1,
+                lines.ionization_energy.values[:, np.newaxis],
+            )
 
-    gammas = calc_gamma(
-        atomic_number=lines.atomic_number.values[:, np.newaxis],
-        ion_number=lines.ion_number.values[:, np.newaxis] + 1,
-        ionization_energy=lines.ionization_energy.values[:, np.newaxis],
-        upper_level_energy=lines.level_energy_upper.values[:, np.newaxis],
-        lower_level_energy=lines.level_energy_lower.values[:, np.newaxis],
-        A_ul=lines.A_ul.values[:, np.newaxis],
-        electron_density=stellar_plasma.electron_densities.values,
-        temperature=stellar_model.temperatures.value,
-        h_density=stellar_plasma.ion_number_density.loc[1, 0].values,
-        linear_stark=linear_stark,
-        quadratic_stark=quadratic_stark,
-        van_der_waals=van_der_waals,
-        radiation=radiation,
-    )
+    else:
+        gammas = calc_gamma(
+            atomic_number=lines.atomic_number.values[:, np.newaxis],
+            ion_number=lines.ion_number.values[:, np.newaxis] + 1,
+            ionization_energy=lines.ionization_energy.values[:, np.newaxis],
+            upper_level_energy=lines.level_energy_upper.values[:, np.newaxis],
+            lower_level_energy=lines.level_energy_lower.values[:, np.newaxis],
+            A_ul=lines.A_ul.values[:, np.newaxis],
+            electron_density=stellar_plasma.electron_densities.values,
+            temperature=stellar_model.temperatures.value,
+            h_density=stellar_plasma.ion_number_density.loc[1, 0].values,
+            linear_stark=linear_stark,
+            quadratic_stark=quadratic_stark,
+            van_der_waals=van_der_waals,
+            radiation=radiation,
+        )
 
     doppler_widths = calc_doppler_width(
         lines.nu.values[:, np.newaxis],
@@ -716,12 +741,34 @@ def calculate_molecule_broadening(
     stellar_plasma,
     broadening_line_opacity_config,
 ):
+    """
+    Calculates broadening information for molecular line at each depth point.
+
+    Parameters
+    ----------
+    lines : DataFrame
+        Dataframe of the lines to calculate broadening for.
+    stellar_model : stardis.model.base.StellarModel
+    stellar_plasma : tardis.plasma.base.BasePlasma
+    broadening_line_opacity_config : tardis.io.configuration.config_reader.Configuration
+        Broadening methods section of the line opacity section of the STARDIS configuration.
+    calc_only_doppler : bool, optional
+        True if only Doppler broadening is to be calculated, otherwise False.
+        By default False.
+
+    Returns
+    -------
+    gammas : numpy.ndarray
+        Array of shape (no_of_lines, no_depth_points). Collisional broadening
+        parameter of each line at each depth point.
+    doppler_widths : numpy.ndarray
+        Array of shape (no_of_lines, no_depth_points). Doppler width of each
+        line at each depth point.
+    """
     if "radiation" in broadening_line_opacity_config:
         gammas = lines.A_ul.values[:, np.newaxis]
     else:
-        gammas = np.zeros(
-            (len(lines), len(stellar_model.geometry.no_of_depth_points)), dtype=float
-        )
+        gammas = np.zeros((len(lines), stellar_model.no_of_depth_points), dtype=float)
 
     ions = stellar_plasma.molecule_ion_map.loc[lines.molecule]
 
@@ -793,3 +840,105 @@ def rotation_broadening(
     )
 
     return wavelength, broadened_fluxes
+
+
+def _calc_vald_vdW_scaled_gamma(vdW, temperature):
+    """
+    see https://github.com/barklem/public-data/tree/master/broadening-howto
+    and Korg https://github.com/ajwheeler/Korg.jl/blob/ff89e57b5f90b06553c10aebacedcb649a451f0b/src/line_absorption.jl#L178
+    """
+    return (10**vdW * (temperature / 1e4) ** 0.3).T
+
+
+def _calc_vald_vdw_unsoeld_approx(
+    vdW,
+    ion_number,
+    ionization_energy,
+    upper_level_energy,
+    lower_level_energy,
+    temperature,
+):
+    """
+    unsoeld approximations are just enhancement factors to multiply approximate vdW values by,
+    so we calculate them as we would normally, and then multiply by the enhancement factor
+    """
+    n_eff_upper = calc_n_effective(ion_number, ionization_energy, upper_level_energy)
+    n_eff_lower = calc_n_effective(ion_number, ionization_energy, lower_level_energy)
+    approx_gamma = calc_gamma_van_der_waals(
+        ion_number,
+        n_eff_upper,
+        n_eff_lower,
+        temperature,
+        np.ones_like(
+            temperature
+        ),  # This is just saying hydrogen density is 1. We multiply by hydrogen density later for all types of vdW broadening
+    )
+    return vdW * approx_gamma
+
+
+def _calc_vald_vdW_abo(vdW, temperature, atomic_mass):
+    """abo calculation of vald parameters, following Korg https://github.com/ajwheeler/Korg.jl/blob/ff89e57b5f90b06553c10aebacedcb649a451f0b/src/line_absorption.jl#L179
+    which cites https://github.com/barklem/public-data/tree/master/broadening-howto
+    vdW values here are packed sigma and alpha, where sigma is pre-decimal point and alpha is post-decimal point
+    1e6 is 1e4 km/s in cgs, which is the measured value for sigmas in the ABO tables
+
+    """
+    vdW_int = vdW.astype(int)
+    sigma = (vdW_int * BOHR_RADIUS * BOHR_RADIUS)[:, np.newaxis]
+    alpha = (vdW - vdW_int)[:, np.newaxis]
+    inverse_reduced_mass = (1 / 1.008 * AMU_CGS) + (1 / atomic_mass)
+    vbar = np.sqrt(8 * BOLTZMANN_CONSTANT * temperature / PI * inverse_reduced_mass)
+    return (
+        2
+        * (4 / PI) ** (alpha / 2)
+        * gamma_func((4 - alpha) / 2)
+        * 1e6
+        * sigma
+        * (vbar / 1e6) ** (1 - alpha)
+    )
+
+
+def calc_vald_vdW(
+    vdW,
+    temperature,
+    atomic_mass,
+    upper_level_energy,
+    lower_level_energy,
+    hydrogen_density,
+    ion_number,
+    ionization_energy,
+):
+    """
+    see https://github.com/barklem/public-data/tree/master/broadening-howto
+
+    Parameters
+    ----------
+    vdW : float
+        van der Waals broadening parameter.
+    """
+    vdW_unscaled_mask = vdW < 0
+    vdW_0_mask = vdW == 0.0
+    vdW_unsoeld_mask = (0 < vdW) & (vdW < 20)
+    vdW_abo_mask = vdW >= 20
+    gamma_vdW = np.zeros((vdW.shape[0], temperature.shape[0]))
+
+    gamma_vdW[vdW_unscaled_mask, :] = _calc_vald_vdW_scaled_gamma(
+        vdW[vdW_unscaled_mask],
+        temperature[:, np.newaxis],
+    )
+
+    gamma_vdW[vdW_0_mask, :] = 0.0
+    gamma_vdW[vdW_unsoeld_mask, :] = _calc_vald_vdw_unsoeld_approx(
+        vdW[vdW_unsoeld_mask],
+        ion_number[vdW_unsoeld_mask],
+        ionization_energy[vdW_unsoeld_mask],
+        upper_level_energy[vdW_unsoeld_mask],
+        lower_level_energy[vdW_unsoeld_mask],
+        temperature,
+    )
+
+    gamma_vdW[vdW_abo_mask, :] = _calc_vald_vdW_abo(
+        vdW[vdW_abo_mask], temperature, atomic_mass[vdW_abo_mask]
+    )
+
+    return gamma_vdW * hydrogen_density

--- a/stardis/radiation_field/opacities/opacities_solvers/broadening.py
+++ b/stardis/radiation_field/opacities/opacities_solvers/broadening.py
@@ -870,8 +870,8 @@ def rotation_broadening(
 
 
 def calc_vald_stark_gamma(electron_density, stark, temperature):
-    """ 
-    see 
+    """
+    see
     """
     stark_gamma = electron_density * 10**stark * (temperature / 1e4) ** (1 / 6)
     stark_gamma = np.where(electron_density * stark >= 0, 0, stark_gamma)
@@ -1045,8 +1045,8 @@ def calc_vald_gamma(
             lines.level_energy_lower[h_indices].values,
         )
         gamma_linear_stark = calc_gamma_linear_stark(
-            n_eff_upper,
-            n_eff_lower,
+            n_eff_upper[:, np.newaxis],
+            n_eff_lower[:, np.newaxis],
             stellar_plasma.electron_densities.values,
         )
         gammas[h_indices, :] += gamma_linear_stark


### PR DESCRIPTION
Built on #225, so we should merge that one first.

This should massively improve the speed of large simulations. Rather than calculating the difference between each the frequency of each line and each frequency grid point, this does a binary search on the wavelength grid to find the closest frequency array index of the line, and then calculates how many indices out we should consider the line for. 

Currently for this I'm just doing (gamma + doppler width) * 20 * alpha_of_line/frequency_bin_width, or 10 bins to each side of the line. This should probably be thought out more, but looks like it gives a good first answer to consider each line out to where appropriate.

This also implements parallelization of this calculation. 