### PR TITLE
Fixes the broken Mamba installation link on "Downloading and Installation" Page in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Setting Up the Environment
 .. note::
    * STARDIS is only supported on macOS and GNU/Linux. Windows users can run STARDIS on a virtual machine.
 
-   * STARDIS packages and dependencies are distributed only through the `conda <https://docs.conda.io/en/latest/>`__ package management system, therefore installation requires a conda distribution to be installed on your system. STARDIS uses `Miniconda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__ or `Mamba <https://mamba.readthedocs.io/en/latest/installation.html>`__ by default. Other distributions are untested.
+   * STARDIS packages and dependencies are distributed only through the `conda <https://docs.conda.io/en/latest/>`__ package management system, therefore installation requires a conda distribution to be installed on your system. STARDIS uses `Miniconda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`__ or `Mamba <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`__ by default. Other distributions are untested.
 
 STARDIS uses exclusively the packages in the TARDIS enviroment, as well
 as using the TARDIS code itself. We strongly suggest that users create a separate


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Replace the broken link `https://mamba.readthedocs.io/en/latest/installation.html` with the correct working link `https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html`


Closes #240

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
