### PR TITLE
api_documentation_workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -54,6 +54,14 @@ jobs:
         run: |
           pip install -e .[docs]
 
+      - name: Generate API Documentation
+        id: generate-api
+        working-directory: docs
+        run: |
+          sphinx-apidoc -o api ../stardis --separate --force
+        continue-on-error: true
+        
+
       - name: Make Sphinx HTML
         id: make-sphinx-html
         run: |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ This is the documentation for STARDIS.
    Downloading and Installation <installation>
    Quickstart <quickstart/quickstart>
    Physics of STARDIS <physics/physics_of_stardis>
+   API <api/modules>
    Contributing <contributing>
    Bibliography <bibliography>
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` 

Adding to the build documentation workflow, this should generate documentation for stardis API on each push. I do not believe this is how tardis does it, but this should in theory work. I could not test this as I could not get the workflow to function locally, but using the same bash command in terminal worked locally.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
