### PR TITLE
fix mesa microturbulence units

### DIFF
--- a/stardis/io/model/mesa.py
+++ b/stardis/io/model/mesa.py
@@ -130,7 +130,12 @@ class MESAModel:
         )
         temperatures = np.exp(self.data.lnT.values[::-1]) * u.K
 
-        return StellarModel(temperatures, mesa_geometry, mesa_composition)
+        return StellarModel(
+            temperatures,
+            mesa_geometry,
+            mesa_composition,
+            microturbulence=0.0 * u.km / u.s,
+        )
 
 
 def read_mesa_metadata(fpath):

--- a/stardis/io/model/mesa.py
+++ b/stardis/io/model/mesa.py
@@ -134,7 +134,6 @@ class MESAModel:
             temperatures,
             mesa_geometry,
             mesa_composition,
-            microturbulence=0.0 * u.km / u.s,
         )
 
 

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -1,4 +1,5 @@
 from tardis.io.util import HDFWriterMixin
+from astropy import units as u
 
 
 class StellarModel(HDFWriterMixin):
@@ -36,7 +37,7 @@ class StellarModel(HDFWriterMixin):
         self.geometry = geometry
         self.composition = composition
         self.spherical = spherical
-        self.microturbulence = microturbulence
+        self.microturbulence = microturbulence * u.km / u.s
 
     @property
     def no_of_depth_points(self):

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -24,7 +24,7 @@ class StellarModel(HDFWriterMixin):
         Class attribute to be easily accessible for initializing arrays that need to match the shape of the model.
     spherical : bool
         Flag for spherical geometry.
-    microturbulence : float
+    microturbulence : astropy.units.Quantity
         Microturbulence in km/s.
     """
 
@@ -37,7 +37,7 @@ class StellarModel(HDFWriterMixin):
         self.geometry = geometry
         self.composition = composition
         self.spherical = spherical
-        self.microturbulence = microturbulence * u.km / u.s
+        self.microturbulence = microturbulence
 
     @property
     def no_of_depth_points(self):

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -1,4 +1,5 @@
 from tardis.io.util import HDFWriterMixin
+from astropy import units as u
 
 
 class StellarModel(HDFWriterMixin):
@@ -30,7 +31,12 @@ class StellarModel(HDFWriterMixin):
     hdf_properties = ["temperatures", "geometry", "composition"]
 
     def __init__(
-        self, temperatures, geometry, composition, spherical=False, microturbulence=0.0
+        self,
+        temperatures,
+        geometry,
+        composition,
+        spherical=False,
+        microturbulence=0.0 * u.km / u.s,
     ):
         self.temperatures = temperatures
         self.geometry = geometry

--- a/stardis/model/base.py
+++ b/stardis/model/base.py
@@ -1,5 +1,4 @@
 from tardis.io.util import HDFWriterMixin
-from astropy import units as u
 
 
 class StellarModel(HDFWriterMixin):


### PR DESCRIPTION
Mesa models were broken because of a unit mismatch. This small patch makes them work again. 

I also created issue #262 as a reminder to make mesa tests so they don't get quietly broken again. 