### PR TITLE
turn off rad field default

### DIFF
--- a/stardis/io/schemas/result_options.yml
+++ b/stardis/io/schemas/result_options.yml
@@ -10,4 +10,4 @@ properties:
         default: false
     return_radiation_field:
         type: boolean
-        default: true
+        default: false


### PR DESCRIPTION
This object can be very big, and most people probably will want to interact with the spectrum, not the full radiation field. 

I think I changed this before, but @RyanGroneck might have accidentally flipped it back on when restructuring the schemas. 