### PR TITLE
[GSoC] bench: add calc_weights and calc_weights_parallel benchmarks

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -362,6 +362,10 @@
       "name": "Beaujean, Frederik",
       "orcid": "0000-0001-9901-8785",
       "affiliation": "Ludwig-Maximilians-Universit\u00e4t M\u00fcnchen Fakult\u00e4t f\u00fcr Physik"
+    },
+    {
+      "name": "Gautam, Deshan",
+      "orcid": "0009-0003-5507-2175"
     }
   ]
 }

--- a/benchmarks/bench_calc_weights.py
+++ b/benchmarks/bench_calc_weights.py
@@ -1,4 +1,3 @@
-# Import necessary code
 import numpy as np
 from stardis.radiation_field.radiation_field_solvers.base import (
     calc_weights,
@@ -25,12 +24,6 @@ class BenchCalcWeightsSmall:
     def time_calc_weights_parallel(self):
         calc_weights_parallel(self.delta_tau)
 
-    def peakmem_calc_weights(self):
-        calc_weights(self.delta_tau)
-
-    def peakmem_calc_weights_parallel(self):
-        calc_weights_parallel(self.delta_tau)
-
 
 class BenchCalcWeightsLarge:
     """
@@ -49,10 +42,4 @@ class BenchCalcWeightsLarge:
         calc_weights(self.delta_tau)
 
     def time_calc_weights_parallel(self):
-        calc_weights_parallel(self.delta_tau)
-
-    def peakmem_calc_weights(self):
-        calc_weights(self.delta_tau)
-
-    def peakmem_calc_weights_parallel(self):
         calc_weights_parallel(self.delta_tau)

--- a/benchmarks/bench_calc_weights.py
+++ b/benchmarks/bench_calc_weights.py
@@ -1,0 +1,58 @@
+# Import necessary code
+import numpy as np
+from stardis.radiation_field.radiation_field_solvers.base import (
+    calc_weights,
+    calc_weights_parallel,
+)
+
+
+class BenchCalcWeightsSmall:
+    """
+    Benchmark calc_weights and calc_weights_parallel on a small
+    grid of 50 depth gaps and 1000 frequencies.
+    """
+
+    timeout = 1800  # Worst case timeout of 30 mins
+
+    def setup(self):
+        rng = np.random.default_rng(42)
+        self.delta_tau = rng.uniform(0, 100, size=(50, 1000))
+        calc_weights_parallel(rng.uniform(0, 100, size=(5, 10)))
+
+    def time_calc_weights(self):
+        calc_weights(self.delta_tau)
+
+    def time_calc_weights_parallel(self):
+        calc_weights_parallel(self.delta_tau)
+
+    def peakmem_calc_weights(self):
+        calc_weights(self.delta_tau)
+
+    def peakmem_calc_weights_parallel(self):
+        calc_weights_parallel(self.delta_tau)
+
+
+class BenchCalcWeightsLarge:
+    """
+    Benchmark calc_weights and calc_weights_parallel on a large
+    grid of 200 depth gaps and 5000 frequencies.
+    """
+
+    timeout = 1800  # Worst case timeout of 30 mins
+
+    def setup(self):
+        rng = np.random.default_rng(42)
+        self.delta_tau = rng.uniform(0, 100, size=(200, 5000))
+        calc_weights_parallel(rng.uniform(0, 100, size=(5, 10)))
+
+    def time_calc_weights(self):
+        calc_weights(self.delta_tau)
+
+    def time_calc_weights_parallel(self):
+        calc_weights_parallel(self.delta_tau)
+
+    def peakmem_calc_weights(self):
+        calc_weights(self.delta_tau)
+
+    def peakmem_calc_weights_parallel(self):
+        calc_weights_parallel(self.delta_tau)


### PR DESCRIPTION
### :pencil: Description
**Type:** :rocket: `feature`

Adds ASV benchmarks for `calc_weights` and `calc_weights_parallel` with two grid sizes (small 50×1000, large 200×5000). Removed `peakmem_` variants since these functions are lightweight and memory tracking adds noise.

Numbers on my machine:
- Small: `calc_weights` ~4.5ms, `calc_weights_parallel` ~0.5ms
- Large: `calc_weights` ~83ms, `calc_weights_parallel` ~19ms
These functions aren't expensive on their own.

### :pushpin: Resources

### :vertical_traffic_light: Testing
- [ ] Testing pipeline
- [x] Other method (describe)

Ran benchmarks locally with `asv run`.

### :ballot_box_with_check: Checklist
- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label